### PR TITLE
Enrich ontologies

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,31 @@ opensyndrome convert --language "Português do Brasil" --edit
 opensyndrome convert --validate
 ```
 
+### Enrich ontology IDs on a JSON definition
+
+The `enrich` command populates `ontology_id` fields on criteria nodes and sets the `@context` to the OpenSyndrome JSON-LD context URL. It queries [EBI OLS4](https://www.ebi.ac.uk/ols4) by default, or [text2term](https://ccb-hms.github.io/ontology-mapper/) as an alternative mapper.
+
+```bash
+# enrich an existing JSON definition (uses OLS4 by default)
+opensyndrome enrich definition.json
+
+# use text2term instead (requires: pip install text2term)
+opensyndrome enrich definition.json --mapper text2term
+
+# review and adjust the result in an editor before printing
+opensyndrome enrich definition.json --edit
+
+# enrich and validate in one step
+opensyndrome enrich definition.json --validate
+```
+
+You can also enrich directly after conversion:
+
+```bash
+opensyndrome convert -hr "Any person with fever and rash" --enrich-ontology
+opensyndrome convert -hr "Any person with fever and rash" --enrich-ontology --mapper text2term
+```
+
 ### Convert a machine-readable JSON syndrome definition to a human-readable format
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -143,6 +143,12 @@ To get started with development, you need to have [uv](https://docs.astral.sh/uv
 uv sync
 ```
 
+To include the optional `text2term` mapper (and its `bioregistry` dependency) so the full test suite runs without skips:
+
+```bash
+uv sync --all-extras
+```
+
 ### Generate Ollama-compatible JSON
 
 > You only need to do this if you are a maintainer adding a new OSI schema or updating an existing one.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The `enrich` command populates `ontology_id` fields on criteria nodes and sets t
 # enrich an existing JSON definition (uses OLS4 by default)
 opensyndrome enrich definition.json
 
-# use text2term instead (requires: pip install text2term)
+# use text2term instead (requires: pip install opensyndrome[text2term])
 opensyndrome enrich definition.json --mapper text2term
 
 # review and adjust the result in an editor before printing

--- a/opensyndrome/cli.py
+++ b/opensyndrome/cli.py
@@ -11,6 +11,7 @@ from opensyndrome.converters import (
     generate_machine_readable_format,
     generate_human_readable_format,
 )
+from opensyndrome.ontology import enrich_definition
 from opensyndrome.artifacts import get_schema_filepath, get_definition_dir
 from opensyndrome.validators import validate_machine_readable_format
 from opensyndrome.providers import (
@@ -107,6 +108,11 @@ def check_provider(func):
     help="Open editor after generation.",
 )
 @click.option(
+    "--enrich-ontology / --no-enrich-ontology",
+    default=False,
+    help="Post-process output to populate ontology IDs via EBI OLS4.",
+)
+@click.option(
     "-hr",
     "--human-readable-definition",
     type=str,
@@ -131,6 +137,7 @@ def convert_to_json(
     model,
     language,
     edit,
+    enrich_ontology,
     human_readable_definition,
     human_readable_definition_file,
     provider,
@@ -155,6 +162,20 @@ def convert_to_json(
     except InstructorRetryException as exception:
         _show_llm_error(exception, provider, model)
         return
+
+    if enrich_ontology:
+        click.echo(click.style("Enriching ontology IDs...", fg="cyan"), err=True)
+
+        def _progress(name, curie):
+            click.echo(
+                click.style(f"  {name} → {curie}"),
+                err=True,
+            )
+
+        machine_readable_definition = enrich_definition(
+            machine_readable_definition,
+            verbose_callback=_progress,
+        )
 
     if edit:
         machine_readable_definition_edited = click.edit(

--- a/opensyndrome/cli.py
+++ b/opensyndrome/cli.py
@@ -110,7 +110,7 @@ def check_provider(func):
 @click.option(
     "--enrich-ontology / --no-enrich-ontology",
     default=False,
-    help="Post-process output to populate ontology IDs via EBI OLS4.",
+    help="Post-process output to populate ontology IDs.",
 )
 @click.option(
     "--mapper",
@@ -213,7 +213,7 @@ def convert_to_json(
     help="Ontology mapper to use.",
 )
 def enrich_json(json_file, edit, validate, mapper):
-    """Populate ontology IDs on an existing JSON definition via EBI OLS4."""
+    """Populate ontology IDs on an existing JSON definition."""
     definition = json.loads(Path(json_file).read_text())
     click.echo(click.style("Enriching ontology IDs...", fg="cyan"), err=True)
 

--- a/opensyndrome/cli.py
+++ b/opensyndrome/cli.py
@@ -11,7 +11,7 @@ from opensyndrome.converters import (
     generate_machine_readable_format,
     generate_human_readable_format,
 )
-from opensyndrome.ontology import enrich_definition
+from opensyndrome.ontology import enrich_definition, MAPPERS
 from opensyndrome.artifacts import get_schema_filepath, get_definition_dir
 from opensyndrome.validators import validate_machine_readable_format
 from opensyndrome.providers import (
@@ -113,6 +113,13 @@ def check_provider(func):
     help="Post-process output to populate ontology IDs via EBI OLS4.",
 )
 @click.option(
+    "--mapper",
+    type=click.Choice(MAPPERS),
+    default="ols",
+    show_default=True,
+    help="Ontology mapper to use with --enrich-ontology.",
+)
+@click.option(
     "-hr",
     "--human-readable-definition",
     type=str,
@@ -138,6 +145,7 @@ def convert_to_json(
     language,
     edit,
     enrich_ontology,
+    mapper,
     human_readable_definition,
     human_readable_definition_file,
     provider,
@@ -174,6 +182,7 @@ def convert_to_json(
 
         machine_readable_definition = enrich_definition(
             machine_readable_definition,
+            mapper=mapper,
             verbose_callback=_progress,
         )
 
@@ -196,7 +205,14 @@ def convert_to_json(
 @click.option(
     "--validate", is_flag=True, help="Validate the JSON file against the schema."
 )
-def enrich_json(json_file, edit, validate):
+@click.option(
+    "--mapper",
+    type=click.Choice(MAPPERS),
+    default="ols",
+    show_default=True,
+    help="Ontology mapper to use.",
+)
+def enrich_json(json_file, edit, validate, mapper):
     """Populate ontology IDs on an existing JSON definition via EBI OLS4."""
     definition = json.loads(Path(json_file).read_text())
     click.echo(click.style("Enriching ontology IDs...", fg="cyan"), err=True)
@@ -204,7 +220,9 @@ def enrich_json(json_file, edit, validate):
     def _progress(name, curie):
         click.echo(click.style(f"  {name} → {curie}"), err=True)
 
-    definition = enrich_definition(definition, verbose_callback=_progress)
+    definition = enrich_definition(
+        definition, mapper=mapper, verbose_callback=_progress
+    )
 
     if edit:
         edited = click.edit(text=json.dumps(definition, indent=4), extension=".json")

--- a/opensyndrome/cli.py
+++ b/opensyndrome/cli.py
@@ -190,6 +190,33 @@ def convert_to_json(
         validate_machine_readable_format_with_style(machine_readable_definition)
 
 
+@cli.command("enrich")
+@click.argument("json_file", type=click.Path(exists=True))
+@click.option("--edit", is_flag=True, help="Open editor after enrichment.")
+@click.option(
+    "--validate", is_flag=True, help="Validate the JSON file against the schema."
+)
+def enrich_json(json_file, edit, validate):
+    """Populate ontology IDs on an existing JSON definition via EBI OLS4."""
+    definition = json.loads(Path(json_file).read_text())
+    click.echo(click.style("Enriching ontology IDs...", fg="cyan"), err=True)
+
+    def _progress(name, curie):
+        click.echo(click.style(f"  {name} → {curie}"), err=True)
+
+    definition = enrich_definition(definition, verbose_callback=_progress)
+
+    if edit:
+        edited = click.edit(text=json.dumps(definition, indent=4), extension=".json")
+        if edited:
+            definition = json.loads(edited)
+
+    click.echo(color_json(definition))
+
+    if validate:
+        validate_machine_readable_format_with_style(definition)
+
+
 @cli.command("humanize")
 @click.argument("json_file", type=click.Path(exists=True))
 @click.option(

--- a/opensyndrome/ontology.py
+++ b/opensyndrome/ontology.py
@@ -1,14 +1,16 @@
 import logging
+from typing import Literal, get_args
 
 import requests
+from ols_client import EBIClient
 
 logger = logging.getLogger(__name__)
 
-OLS4_SEARCH_URL = "https://www.ebi.ac.uk/ols4/api/search"
 OPENSYNDROME_CONTEXT_URL = "https://opensyndrome.org/schema/v1/context.jsonld"
 SKIP_TYPES = {"criterion", "demographic_criteria"}
-MIN_SCORE = 5.0
 TEXT2TERM_MIN_SCORE = 0.5
+
+ols = EBIClient()
 
 CRITERION_TYPE_ONTOLOGIES = {
     "symptom": ["mondo", "hp"],
@@ -19,52 +21,60 @@ CRITERION_TYPE_ONTOLOGIES = {
     "professional_judgment": ["hp", "efo"],
 }
 
-MAPPERS = ("ols", "text2term")
+type Mapper = Literal["ols", "text2term"]
+MAPPERS: tuple[Mapper, ...] = get_args(Mapper.__value__)
 
 
 def _pick_best(docs: list[dict], name: str) -> str | None:
     for doc in docs:
         if doc.get("label", "").lower() == name.lower():
-            return doc["short_form"].replace("_", ":", 1)
-    for doc in docs:
-        score = doc.get("score")
-        if score is not None and float(score) >= MIN_SCORE:
-            return doc["short_form"].replace("_", ":", 1)
+            return doc["obo_id"]
     return None
 
 
 def _search_ols(name: str, ontologies: list[str], timeout: int = 10) -> str | None:
-    base_params = {"ontology": ",".join(ontologies), "rows": 5, "type": "class"}
+    base_params = {
+        "q": name,
+        "ontology": ",".join(ontologies),
+        "rows": 5,
+        "type": "class",
+    }
     try:
-        response = requests.get(
-            OLS4_SEARCH_URL,
-            params={"q": name, **base_params},
-            timeout=timeout,
-        )
-        response.raise_for_status()
-        docs = response.json().get("response", {}).get("docs", [])
+        payload = ols.get_json("/search", params=base_params, timeout=timeout)
+        docs = payload.get("response", {}).get("docs", [])
         result = _pick_best(docs, name)
         if result:
             return result
 
-        # Fallback: search synonyms
-        response = requests.get(
-            OLS4_SEARCH_URL,
-            params={"q": name, "queryFields": "label,synonym", **base_params},
+        payload = ols.get_json(
+            "/search",
+            params={**base_params, "queryFields": "label,synonym"},
             timeout=timeout,
         )
-        response.raise_for_status()
-        docs = response.json().get("response", {}).get("docs", [])
+        docs = payload.get("response", {}).get("docs", [])
         return _pick_best(docs, name)
     except requests.RequestException as exc:
         logger.warning("OLS4 search failed for %r: %s", name, exc)
         return None
 
 
-def _iri_to_curie(iri: str) -> str:
-    """Convert an OBO IRI to a CURIE. e.g. http://purl.obolibrary.org/obo/HP_0001945 → HP:0001945"""
-    local = iri.rstrip("/").rsplit("/", 1)[-1]
-    return local.replace("_", ":", 1)
+def _iri_to_curie(iri: str) -> str | None:
+    """Convert an ontology IRI to a CURIE. e.g. http://purl.obolibrary.org/obo/HP_0001945 → HP:0001945"""
+    import bioregistry
+
+    try:
+        prefix, identifier = bioregistry.parse_iri(iri, use_preferred=True)
+    except TypeError:
+        # bioregistry v0.11.35 raises on unparseable IRIs instead of returning (None, None).
+        return None
+    if not prefix:
+        return None
+    # bioregistry uses "obo" as a generic fallback for unrecognized OBO PURLs
+    # e.g. LOINC_2345-7, UNKNOWN_42
+    # reject to avoid producing OBO:* CURIEs
+    if prefix.lower() == "obo" and "_" in identifier:
+        return None
+    return f"{prefix.upper()}:{identifier}"
 
 
 def _search_text2term(
@@ -73,11 +83,13 @@ def _search_text2term(
     try:
         import text2term
     except ImportError:
-        raise ImportError("text2term is not installed. Run: pip install text2term")
+        raise ImportError(
+            "text2term is not installed. Run: pip install text2term"
+        ) from None
 
     for ontology in ontologies:
         try:
-            use_cache = text2term.cache.is_ontology_in_cache(ontology.upper())
+            use_cache = text2term.cache_exists(ontology.upper())
             df = text2term.map_terms(
                 source_terms=[name],
                 target_ontology=ontology.upper(),
@@ -87,8 +99,10 @@ def _search_text2term(
                 excl_deprecated=True,
             )
             if not df.empty:
-                return _iri_to_curie(df.iloc[0]["Mapped Term IRI"])
-        except Exception as exc:
+                curie = _iri_to_curie(df.iloc[0]["Mapped Term IRI"])
+                if curie:
+                    return curie
+        except (requests.RequestException, OSError, RuntimeError, ValueError) as exc:
             logger.warning(
                 "text2term search failed for %r with %s: %s", name, ontology, exc
             )
@@ -129,7 +143,7 @@ def _apply_mapping(
 def enrich_definition(
     definition: dict,
     *,
-    mapper: str = "ols",
+    mapper: Mapper = "ols",
     verbose_callback=None,
 ) -> dict:
     if mapper not in MAPPERS:

--- a/opensyndrome/ontology.py
+++ b/opensyndrome/ontology.py
@@ -1,0 +1,114 @@
+import logging
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+OLS4_SEARCH_URL = "https://www.ebi.ac.uk/ols4/api/search"
+OPENSYNDROME_CONTEXT_URL = "https://opensyndrome.org/schema/v1/context.jsonld"
+SKIP_TYPES = {"criterion", "demographic_criteria"}
+MIN_SCORE = 5.0
+
+CRITERION_TYPE_ONTOLOGIES = {
+    "symptom": ["mondo", "hp"],
+    "diagnosis": ["mondo", "efo"],
+    "syndrome": ["mondo", "efo"],
+    "diagnostic_test": ["loinc", "obi"],
+    "epidemiological_history": ["hp", "efo"],
+    "professional_judgment": ["hp", "efo"],
+}
+
+
+def _pick_best(docs: list[dict], name: str) -> str | None:
+    for doc in docs:
+        if doc.get("label", "").lower() == name.lower():
+            return doc["short_form"].replace("_", ":", 1)
+    for doc in docs:
+        score = doc.get("score")
+        if score is None or float(score) >= MIN_SCORE:
+            return doc["short_form"].replace("_", ":", 1)
+    return None
+
+
+def _search_ols(name: str, ontologies: list[str], timeout: int = 10) -> str | None:
+    base_params = {"ontology": ",".join(ontologies), "rows": 5, "type": "class"}
+    try:
+        response = requests.get(
+            OLS4_SEARCH_URL,
+            params={"q": name, **base_params},
+            timeout=timeout,
+        )
+        response.raise_for_status()
+        docs = response.json().get("response", {}).get("docs", [])
+        result = _pick_best(docs, name)
+        if result:
+            return result
+
+        # Fallback: search synonyms
+        response = requests.get(
+            OLS4_SEARCH_URL,
+            params={"q": name, "queryFields": "label,synonym", **base_params},
+            timeout=timeout,
+        )
+        response.raise_for_status()
+        docs = response.json().get("response", {}).get("docs", [])
+        return _pick_best(docs, name)
+    except requests.RequestException as exc:
+        logger.warning("OLS4 search failed for %r: %s", name, exc)
+        return None
+
+
+def _collect_enrichable(criteria: list[dict]) -> list[dict]:
+    result = []
+    for criterion in criteria:
+        result.extend(_collect_enrichable(criterion.get("values") or []))
+        type_ = criterion.get("type")
+        if not type_ or type_ in SKIP_TYPES:
+            continue
+        if criterion.get("ontology_id"):
+            continue
+        if not (criterion.get("name") or "").strip():
+            continue
+        result.append(criterion)
+    return result
+
+
+def _apply_mapping(
+    criteria: list[dict],
+    mapping: dict[str, str],
+    verbose_callback=None,
+) -> None:
+    for criterion in criteria:
+        _apply_mapping(criterion.get("values", []), mapping, verbose_callback)
+        name = criterion.get("name", "")
+        if name in mapping:
+            criterion["ontology_id"] = mapping[name]
+            if verbose_callback:
+                verbose_callback(name, mapping[name])
+
+
+def enrich_definition(
+    definition: dict,
+    *,
+    verbose_callback=None,
+) -> dict:
+    inclusion_criteria = definition.get("inclusion_criteria") or []
+    exclusion_criteria = definition.get("exclusion_criteria") or []
+    definition["@context"] = OPENSYNDROME_CONTEXT_URL
+    enrichable = _collect_enrichable(inclusion_criteria + exclusion_criteria)
+    if not enrichable:
+        return definition
+
+    mapping: dict[str, str] = {}
+    for criterion in enrichable:
+        name = criterion["name"]
+        type_ = criterion["type"]
+        ontologies = CRITERION_TYPE_ONTOLOGIES.get(type_, ["hp", "efo", "mondo"])
+        curie = _search_ols(name, ontologies)
+        if curie:
+            mapping[name] = curie
+
+    for criteria_list in [inclusion_criteria, exclusion_criteria]:
+        _apply_mapping(criteria_list, mapping, verbose_callback)
+
+    return definition

--- a/opensyndrome/ontology.py
+++ b/opensyndrome/ontology.py
@@ -8,6 +8,7 @@ OLS4_SEARCH_URL = "https://www.ebi.ac.uk/ols4/api/search"
 OPENSYNDROME_CONTEXT_URL = "https://opensyndrome.org/schema/v1/context.jsonld"
 SKIP_TYPES = {"criterion", "demographic_criteria"}
 MIN_SCORE = 5.0
+TEXT2TERM_MIN_SCORE = 0.5
 
 CRITERION_TYPE_ONTOLOGIES = {
     "symptom": ["mondo", "hp"],
@@ -17,6 +18,8 @@ CRITERION_TYPE_ONTOLOGIES = {
     "epidemiological_history": ["hp", "efo"],
     "professional_judgment": ["hp", "efo"],
 }
+
+MAPPERS = ("ols", "text2term")
 
 
 def _pick_best(docs: list[dict], name: str) -> str | None:
@@ -58,6 +61,39 @@ def _search_ols(name: str, ontologies: list[str], timeout: int = 10) -> str | No
         return None
 
 
+def _iri_to_curie(iri: str) -> str:
+    """Convert an OBO IRI to a CURIE. e.g. http://purl.obolibrary.org/obo/HP_0001945 → HP:0001945"""
+    local = iri.rstrip("/").rsplit("/", 1)[-1]
+    return local.replace("_", ":", 1)
+
+
+def _search_text2term(
+    name: str, ontologies: list[str], min_score: float = TEXT2TERM_MIN_SCORE
+) -> str | None:
+    try:
+        import text2term
+    except ImportError:
+        raise ImportError("text2term is not installed. Run: pip install text2term")
+
+    for ontology in ontologies:
+        try:
+            df = text2term.map_terms(
+                source_terms=[name],
+                target_ontology=ontology.upper(),
+                max_mappings=1,
+                min_score=min_score,
+                # use_cache=True,
+                excl_deprecated=True,
+            )
+            if not df.empty:
+                return _iri_to_curie(df.iloc[0]["Mapped Term IRI"])
+        except Exception as exc:
+            logger.warning(
+                "text2term search failed for %r with %s: %s", name, ontology, exc
+            )
+    return None
+
+
 def _collect_enrichable(criteria: list[dict]) -> list[dict]:
     result = []
     for criterion in criteria:
@@ -92,8 +128,16 @@ def _apply_mapping(
 def enrich_definition(
     definition: dict,
     *,
+    mapper: str = "ols",
     verbose_callback=None,
 ) -> dict:
+    if mapper not in MAPPERS:
+        raise ValueError(
+            f"Unknown mapper {mapper!r}. Choose from: {', '.join(MAPPERS)}"
+        )
+
+    search_fn = _search_ols if mapper == "ols" else _search_text2term
+
     inclusion_criteria = definition.get("inclusion_criteria") or []
     exclusion_criteria = definition.get("exclusion_criteria") or []
     definition["@context"] = OPENSYNDROME_CONTEXT_URL
@@ -106,7 +150,7 @@ def enrich_definition(
         name = criterion["name"]
         type_ = criterion["type"]
         ontologies = CRITERION_TYPE_ONTOLOGIES.get(type_, ["hp", "efo", "mondo"])
-        curie = _search_ols(name, ontologies)
+        curie = search_fn(name, ontologies)
         if curie:
             mapping[name] = curie
 

--- a/opensyndrome/ontology.py
+++ b/opensyndrome/ontology.py
@@ -25,7 +25,7 @@ def _pick_best(docs: list[dict], name: str) -> str | None:
             return doc["short_form"].replace("_", ":", 1)
     for doc in docs:
         score = doc.get("score")
-        if score is None or float(score) >= MIN_SCORE:
+        if score is not None and float(score) >= MIN_SCORE:
             return doc["short_form"].replace("_", ":", 1)
     return None
 
@@ -80,6 +80,8 @@ def _apply_mapping(
 ) -> None:
     for criterion in criteria:
         _apply_mapping(criterion.get("values", []), mapping, verbose_callback)
+        if criterion.get("type") in SKIP_TYPES:
+            continue
         name = criterion.get("name", "")
         if name in mapping:
             criterion["ontology_id"] = mapping[name]

--- a/opensyndrome/ontology.py
+++ b/opensyndrome/ontology.py
@@ -77,12 +77,13 @@ def _search_text2term(
 
     for ontology in ontologies:
         try:
+            use_cache = text2term.cache.is_ontology_in_cache(ontology.upper())
             df = text2term.map_terms(
                 source_terms=[name],
                 target_ontology=ontology.upper(),
                 max_mappings=1,
                 min_score=min_score,
-                # use_cache=True,
+                use_cache=use_cache,
                 excl_deprecated=True,
             )
             if not df.empty:

--- a/opensyndrome/ontology.py
+++ b/opensyndrome/ontology.py
@@ -32,30 +32,33 @@ def _pick_best(docs: list[dict], name: str) -> str | None:
     return None
 
 
-def _search_ols(name: str, ontologies: list[str], timeout: int = 10) -> str | None:
-    base_params = {
-        "q": name,
-        "ontology": ",".join(ontologies),
-        "rows": 5,
-        "type": "class",
-    }
-    try:
-        payload = ols.get_json("/search", params=base_params, timeout=timeout)
-        docs = payload.get("response", {}).get("docs", [])
-        result = _pick_best(docs, name)
-        if result:
-            return result
-
-        payload = ols.get_json(
-            "/search",
-            params={**base_params, "queryFields": "label,synonym"},
-            timeout=timeout,
-        )
-        docs = payload.get("response", {}).get("docs", [])
-        return _pick_best(docs, name)
-    except requests.RequestException as exc:
-        logger.warning("OLS4 search failed for %r: %s", name, exc)
-        return None
+def _search_ols(queries: dict[str, list[str]], timeout: int = 10) -> dict[str, str]:
+    """Map names to CURIEs via OLS4 (one HTTP call per name; per-name failures are isolated)."""
+    result: dict[str, str] = {}
+    for name, ontologies in queries.items():
+        base_params = {
+            "q": name,
+            "ontology": ",".join(ontologies),
+            "rows": 5,
+            "type": "class",
+        }
+        try:
+            payload = ols.get_json("/search", params=base_params, timeout=timeout)
+            docs = payload.get("response", {}).get("docs", [])
+            curie = _pick_best(docs, name)
+            if not curie:
+                payload = ols.get_json(
+                    "/search",
+                    params={**base_params, "queryFields": "label,synonym"},
+                    timeout=timeout,
+                )
+                docs = payload.get("response", {}).get("docs", [])
+                curie = _pick_best(docs, name)
+            if curie:
+                result[name] = curie
+        except requests.RequestException as exc:
+            logger.warning("OLS4 search failed for %r: %s", name, exc)
+    return result
 
 
 def _iri_to_curie(iri: str) -> str | None:
@@ -78,8 +81,10 @@ def _iri_to_curie(iri: str) -> str | None:
 
 
 def _search_text2term(
-    name: str, ontologies: list[str], min_score: float = TEXT2TERM_MIN_SCORE
-) -> str | None:
+    queries: dict[str, list[str]],
+    min_score: float = TEXT2TERM_MIN_SCORE,
+) -> dict[str, str]:
+    """Batch-map names to CURIEs via text2term, loading each ontology at most once."""
     try:
         import text2term
     except ImportError:
@@ -87,26 +92,45 @@ def _search_text2term(
             "text2term is not installed. Run: pip install text2term"
         ) from None
 
-    for ontology in ontologies:
+    names_per_ontology: dict[str, set[str]] = {}
+    for name, ontologies in queries.items():
+        for ontology in ontologies:
+            names_per_ontology.setdefault(ontology.upper(), set()).add(name)
+
+    matches_per_ontology: dict[str, dict[str, str]] = {}
+    for ontology, names in names_per_ontology.items():
         try:
-            use_cache = text2term.cache_exists(ontology.upper())
+            use_cache = text2term.cache_exists(ontology)
             df = text2term.map_terms(
-                source_terms=[name],
-                target_ontology=ontology.upper(),
+                source_terms=sorted(names),
+                target_ontology=ontology,
                 max_mappings=1,
                 min_score=min_score,
                 use_cache=use_cache,
                 excl_deprecated=True,
             )
-            if not df.empty:
-                curie = _iri_to_curie(df.iloc[0]["Mapped Term IRI"])
+            ontology_matches: dict[str, str] = {}
+            for _, row in df.iterrows():
+                curie = _iri_to_curie(row["Mapped Term IRI"])
                 if curie:
-                    return curie
+                    ontology_matches[row["Source Term"]] = curie
+            matches_per_ontology[ontology] = ontology_matches
         except (requests.RequestException, OSError, RuntimeError, ValueError) as exc:
             logger.warning(
-                "text2term search failed for %r with %s: %s", name, ontology, exc
+                "text2term batch failed for %s (%d terms): %s",
+                ontology,
+                len(names),
+                exc,
             )
-    return None
+
+    result: dict[str, str] = {}
+    for name, ontologies in queries.items():
+        for ontology in ontologies:
+            curie = matches_per_ontology.get(ontology.upper(), {}).get(name)
+            if curie:
+                result[name] = curie
+                break
+    return result
 
 
 def _collect_enrichable(criteria: list[dict]) -> list[dict]:
@@ -160,14 +184,11 @@ def enrich_definition(
     if not enrichable:
         return definition
 
-    mapping: dict[str, str] = {}
-    for criterion in enrichable:
-        name = criterion["name"]
-        type_ = criterion["type"]
-        ontologies = CRITERION_TYPE_ONTOLOGIES.get(type_, ["hp", "efo", "mondo"])
-        curie = search_fn(name, ontologies)
-        if curie:
-            mapping[name] = curie
+    queries: dict[str, list[str]] = {
+        c["name"]: CRITERION_TYPE_ONTOLOGIES.get(c["type"], ["hp", "efo", "mondo"])
+        for c in enrichable
+    }
+    mapping = search_fn(queries)
 
     for criteria_list in [inclusion_criteria, exclusion_criteria]:
         _apply_mapping(criteria_list, mapping, verbose_callback)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,13 +18,14 @@ dependencies = [
     "datamodel-code-generator>=0.55.0",
     "litellm>=1.82.2",
     "instructor>=1.14.5",
+    "ols-client>=0.2.1",
 ]
 
 [project.scripts]
 opensyndrome = "opensyndrome.cli:main"
 
 [project.optional-dependencies]
-text2term = ["text2term>=4.5.0"]
+text2term = ["text2term>=4.5.0", "bioregistry>=0.11.35"]
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "pygments>=2.19.1,<3",
     "python-dotenv>=1.0.1,<2",
     "pydantic>=2.10.6,<3",
-    "numpy>=2.3.1,<3",
     "pyarrow>=20.0.0,<21",
     "ollama>=0.5.1,<0.6",
     "requests>=2.32.5",
@@ -23,6 +22,9 @@ dependencies = [
 
 [project.scripts]
 opensyndrome = "opensyndrome.cli:main"
+
+[project.optional-dependencies]
+text2term = ["text2term>=4.5.0"]
 
 [dependency-groups]
 dev = [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -229,6 +229,49 @@ class TestConvertToJson:
         assert result.exit_code == 1
 
 
+class TestEnrichJson:
+    @pytest.fixture
+    def runner(self):
+        return CliRunner()
+
+    @pytest.fixture
+    def json_file(self, tmp_path):
+        f = tmp_path / "definition.json"
+        f.write_text('{"inclusion_criteria": [{"type": "symptom", "name": "Fever"}]}')
+        return f
+
+    def test_enrich_calls_enrich_definition(self, runner, json_file, mocker):
+        mock_enrich = mocker.patch(
+            "opensyndrome.cli.enrich_definition",
+            return_value={"inclusion_criteria": []},
+        )
+        result = runner.invoke(cli, ["enrich", str(json_file)])
+        assert result.exit_code == 0
+        mock_enrich.assert_called_once()
+
+    def test_enrich_passes_definition_from_file(self, runner, json_file, mocker):
+        mock_enrich = mocker.patch(
+            "opensyndrome.cli.enrich_definition",
+            return_value={"inclusion_criteria": []},
+        )
+        runner.invoke(cli, ["enrich", str(json_file)])
+        passed = mock_enrich.call_args.args[0]
+        assert passed == {"inclusion_criteria": [{"type": "symptom", "name": "Fever"}]}
+
+    def test_enrich_nonexistent_file_exits_with_error(self, runner):
+        result = runner.invoke(cli, ["enrich", "nonexistent.json"])
+        assert result.exit_code == 2
+
+    def test_enrich_outputs_json(self, runner, json_file, mocker):
+        mocker.patch(
+            "opensyndrome.cli.enrich_definition",
+            return_value={"inclusion_criteria": [], "@context": "http://example.com"},
+        )
+        result = runner.invoke(cli, ["enrich", str(json_file)])
+        assert result.exit_code == 0
+        assert "@context" in result.output
+
+
 class TestConvertToText:
     @pytest.fixture(autouse=True)
     def isolate_env(self, mocker):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -72,10 +72,11 @@ class TestCheckProviderAvailable:
 
 class TestConvertToJson:
     @pytest.fixture(autouse=True)
-    def isolate_env(self, mocker):
+    def isolate_env(self, mocker, monkeypatch):
         mocker.patch.dict(
             "os.environ", {"OPENSYNDROME_PROVIDER": "ollama"}, clear=False
         )
+        monkeypatch.delenv("OPENSYNDROME_MODEL", raising=False)
 
     @pytest.fixture
     def runner(self):
@@ -290,10 +291,11 @@ class TestEnrichJson:
 
 class TestConvertToText:
     @pytest.fixture(autouse=True)
-    def isolate_env(self, mocker):
+    def isolate_env(self, mocker, monkeypatch):
         mocker.patch.dict(
             "os.environ", {"OPENSYNDROME_PROVIDER": "ollama"}, clear=False
         )
+        monkeypatch.delenv("OPENSYNDROME_MODEL", raising=False)
 
     @pytest.fixture
     def runner(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -192,6 +192,27 @@ class TestConvertToJson:
         result = runner.invoke(cli, ["convert", "-hr", "Any person with pneumonia"])
         assert result.exit_code == 1
 
+    def test_convert_with_enrich_ontology_calls_enrich(
+        self, runner, mock_convert, mock_provider_available, mocker
+    ):
+        mock_enrich = mocker.patch(
+            "opensyndrome.cli.enrich_definition",
+            return_value={"name": "Pneumonia"},
+        )
+        result = runner.invoke(
+            cli, ["convert", "-hr", "Any person with pneumonia", "--enrich-ontology"]
+        )
+        assert result.exit_code == 0
+        mock_enrich.assert_called_once()
+
+    def test_convert_without_enrich_ontology_skips_enrich(
+        self, runner, mock_convert, mock_provider_available, mocker
+    ):
+        mock_enrich = mocker.patch("opensyndrome.cli.enrich_definition")
+        result = runner.invoke(cli, ["convert", "-hr", "Any person with pneumonia"])
+        assert result.exit_code == 0
+        mock_enrich.assert_not_called()
+
     def test_convert_shows_friendly_error_on_rate_limit(
         self, runner, mock_provider_available, mocker
     ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -271,6 +271,22 @@ class TestEnrichJson:
         assert result.exit_code == 0
         assert "@context" in result.output
 
+    def test_enrich_passes_mapper_to_enrich_definition(self, runner, json_file, mocker):
+        mock_enrich = mocker.patch(
+            "opensyndrome.cli.enrich_definition",
+            return_value={"inclusion_criteria": []},
+        )
+        runner.invoke(cli, ["enrich", str(json_file), "--mapper", "text2term"])
+        assert mock_enrich.call_args.kwargs["mapper"] == "text2term"
+
+    def test_enrich_default_mapper_is_ols(self, runner, json_file, mocker):
+        mock_enrich = mocker.patch(
+            "opensyndrome.cli.enrich_definition",
+            return_value={"inclusion_criteria": []},
+        )
+        runner.invoke(cli, ["enrich", str(json_file)])
+        assert mock_enrich.call_args.kwargs["mapper"] == "ols"
+
 
 class TestConvertToText:
     @pytest.fixture(autouse=True)

--- a/tests/test_ontology.py
+++ b/tests/test_ontology.py
@@ -82,12 +82,33 @@ class _FakeDF:
     def iloc(self):
         return self._rows
 
+    def iterrows(self):
+        for index, row in enumerate(self._rows):
+            yield index, row
+
 
 _EMPTY_DF = _FakeDF([])
 
 
-def _ols_df(iri: str, score: float = 0.9) -> _FakeDF:
-    return _FakeDF([{"Mapped Term IRI": iri, "Mapping Score": score}])
+def _ols_df(iri: str, source_term: str = "", score: float = 0.9) -> _FakeDF:
+    return _FakeDF(
+        [{"Source Term": source_term, "Mapped Term IRI": iri, "Mapping Score": score}]
+    )
+
+
+def _text2term_map_fn(per_ontology):
+    """Build a map_terms side_effect: returns rows for (src, iri) pairs registered per ontology."""
+
+    def _map_terms(*, source_terms, target_ontology, **kwargs):
+        pairs = per_ontology.get(target_ontology, [])
+        rows = [
+            {"Source Term": src, "Mapped Term IRI": iri, "Mapping Score": 0.9}
+            for src, iri in pairs
+            if src in source_terms
+        ]
+        return _FakeDF(rows)
+
+    return _map_terms
 
 
 class TestSearchText2term:
@@ -104,49 +125,91 @@ class TestSearchText2term:
 
     def test_returns_curie_on_match(self):
         sys.modules["text2term"] = _make_text2term_module(
-            map_terms_return=_ols_df("http://purl.obolibrary.org/obo/HP_0001945")
+            map_terms_side_effect=_text2term_map_fn(
+                {"HP": [("Fever", "http://purl.obolibrary.org/obo/HP_0001945")]}
+            )
         )
-        assert _search_text2term("Fever", ["hp"]) == "HP:0001945"
+        assert _search_text2term({"Fever": ["hp"]}) == {"Fever": "HP:0001945"}
 
-    def test_tries_next_ontology_on_empty(self):
+    def test_falls_back_to_next_ontology_on_empty(self):
         sys.modules["text2term"] = _make_text2term_module(
-            map_terms_side_effect=[
-                _EMPTY_DF,
-                _ols_df("http://purl.obolibrary.org/obo/MONDO_0005148"),
-            ]
+            map_terms_side_effect=_text2term_map_fn(
+                {"MONDO": [("Dengue", "http://purl.obolibrary.org/obo/MONDO_0005148")]}
+            )
         )
-        assert _search_text2term("Dengue", ["hp", "mondo"]) == "MONDO:0005148"
+        assert _search_text2term({"Dengue": ["hp", "mondo"]}) == {
+            "Dengue": "MONDO:0005148"
+        }
 
-    def test_returns_none_when_all_empty(self):
-        sys.modules["text2term"] = _make_text2term_module(map_terms_return=_EMPTY_DF)
-        assert _search_text2term("Unknown", ["hp"]) is None
+    def test_returns_empty_when_no_match(self):
+        sys.modules["text2term"] = _make_text2term_module(
+            map_terms_side_effect=_text2term_map_fn({})
+        )
+        assert _search_text2term({"Unknown": ["hp"]}) == {}
 
-    def test_returns_none_on_request_exception(self):
+    def test_skips_ontology_on_request_exception(self):
         sys.modules["text2term"] = _make_text2term_module(
             map_terms_side_effect=requests.RequestException("network error")
         )
-        assert _search_text2term("Fever", ["hp"]) is None
+        assert _search_text2term({"Fever": ["hp"]}) == {}
 
     def test_unexpected_exception_propagates(self):
         sys.modules["text2term"] = _make_text2term_module(
             map_terms_side_effect=AttributeError("bug in text2term")
         )
         with pytest.raises(AttributeError, match="bug in text2term"):
-            _search_text2term("Fever", ["hp"])
+            _search_text2term({"Fever": ["hp"]})
 
     def test_unparseable_iri_falls_through_to_next_ontology(self):
         sys.modules["text2term"] = _make_text2term_module(
-            map_terms_side_effect=[
-                _ols_df("garbage://nonsense"),
-                _ols_df("http://purl.obolibrary.org/obo/MONDO_0005148"),
-            ]
+            map_terms_side_effect=_text2term_map_fn(
+                {
+                    "HP": [("Dengue", "garbage://nonsense")],
+                    "MONDO": [
+                        ("Dengue", "http://purl.obolibrary.org/obo/MONDO_0005148")
+                    ],
+                }
+            )
         )
-        assert _search_text2term("Dengue", ["hp", "mondo"]) == "MONDO:0005148"
+        assert _search_text2term({"Dengue": ["hp", "mondo"]}) == {
+            "Dengue": "MONDO:0005148"
+        }
+
+    def test_priority_order_within_query_is_respected(self):
+        sys.modules["text2term"] = _make_text2term_module(
+            map_terms_side_effect=_text2term_map_fn(
+                {
+                    "HP": [("Fever", "http://purl.obolibrary.org/obo/HP_0001945")],
+                    "MONDO": [
+                        ("Fever", "http://purl.obolibrary.org/obo/MONDO_9999999")
+                    ],
+                }
+            )
+        )
+        assert _search_text2term({"Fever": ["mondo", "hp"]}) == {
+            "Fever": "MONDO:9999999"
+        }
+
+    def test_batch_loads_each_ontology_once(self):
+        sys.modules["text2term"] = _make_text2term_module(
+            map_terms_side_effect=_text2term_map_fn(
+                {
+                    "MONDO": [
+                        ("Dengue", "http://purl.obolibrary.org/obo/MONDO_0005148"),
+                        ("Malaria", "http://purl.obolibrary.org/obo/MONDO_0005136"),
+                    ],
+                }
+            )
+        )
+        queries = {"Dengue": ["mondo"], "Malaria": ["mondo"]}
+        result = _search_text2term(queries)
+        assert result == {"Dengue": "MONDO:0005148", "Malaria": "MONDO:0005136"}
+        assert sys.modules["text2term"].map_terms.call_count == 1
 
     def test_raises_on_missing_library(self):
         sys.modules["text2term"] = None
         with pytest.raises(ImportError, match="text2term is not installed"):
-            _search_text2term("Fever", ["hp"])
+            _search_text2term({"Fever": ["hp"]})
 
 
 class TestCollectEnrichable:
@@ -259,14 +322,14 @@ class TestSearchOls:
     def test_returns_curie_on_exact_match(self):
         with patch("opensyndrome.ontology.ols.get_json") as mock_get:
             mock_get.return_value = _ols_payload([_ols_doc("Fever", "HP:0001945")])
-            result = _search_ols("Fever", ["hp"])
-        assert result == "HP:0001945"
+            result = _search_ols({"Fever": ["hp"]})
+        assert result == {"Fever": "HP:0001945"}
 
-    def test_returns_none_on_empty_docs(self):
+    def test_returns_empty_when_no_match(self):
         with patch("opensyndrome.ontology.ols.get_json") as mock_get:
             mock_get.return_value = _ols_payload([])
-            result = _search_ols("Unknown term", ["hp"])
-        assert result is None
+            result = _search_ols({"Unknown term": ["hp"]})
+        assert result == {}
 
     def test_falls_back_to_synonym_search(self):
         synonym_hit = _ols_payload([_ols_doc("rash", "HP:0000988")])
@@ -274,23 +337,23 @@ class TestSearchOls:
             "opensyndrome.ontology.ols.get_json",
             side_effect=[_ols_payload([]), synonym_hit],
         ) as mock_get:
-            result = _search_ols("rash", ["hp"])
-        assert result == "HP:0000988"
+            result = _search_ols({"rash": ["hp"]})
+        assert result == {"rash": "HP:0000988"}
         assert mock_get.call_count == 2
         assert mock_get.call_args_list[1].kwargs["params"]["queryFields"] == (
             "label,synonym"
         )
 
-    def test_returns_none_on_request_exception(self):
+    def test_skips_name_on_request_exception(self):
         with patch("opensyndrome.ontology.ols.get_json") as mock_get:
             mock_get.side_effect = requests.RequestException("timeout")
-            result = _search_ols("Fever", ["hp"])
-        assert result is None
+            result = _search_ols({"Fever": ["hp"]})
+        assert result == {}
 
     def test_passes_ontology_filter_to_client(self):
         with patch("opensyndrome.ontology.ols.get_json") as mock_get:
             mock_get.return_value = _ols_payload([])
-            _search_ols("Fever", ["hp", "mondo"])
+            _search_ols({"Fever": ["hp", "mondo"]})
         params = mock_get.call_args.kwargs["params"]
         assert params["ontology"] == "hp,mondo"
         assert params["type"] == "class"
@@ -298,25 +361,38 @@ class TestSearchOls:
     def test_passes_explicit_timeout_to_client(self):
         with patch("opensyndrome.ontology.ols.get_json") as mock_get:
             mock_get.return_value = _ols_payload([])
-            _search_ols("Fever", ["hp"], timeout=15)
+            _search_ols({"Fever": ["hp"]}, timeout=15)
         assert mock_get.call_args.kwargs["timeout"] == 15
+
+    def test_resilient_when_one_name_fails(self):
+        with patch("opensyndrome.ontology.ols.get_json") as mock_get:
+            mock_get.side_effect = [
+                requests.RequestException("timeout"),
+                _ols_payload([_ols_doc("Rash", "HP:0000988")]),
+            ]
+            result = _search_ols({"Fever": ["hp"], "Rash": ["hp"]})
+        assert result == {"Rash": "HP:0000988"}
 
 
 class TestEnrichDefinition:
     def test_sets_context(self, mocker):
-        mocker.patch("opensyndrome.ontology._search_ols", return_value=None)
+        mocker.patch("opensyndrome.ontology._search_ols", return_value={})
         definition = {"inclusion_criteria": [{"type": "symptom", "name": "Fever"}]}
         result = enrich_definition(definition)
         assert result["@context"] == OPENSYNDROME_CONTEXT_URL
 
     def test_applies_mapping_to_inclusion_criteria(self, mocker):
-        mocker.patch("opensyndrome.ontology._search_ols", return_value="HP:0001945")
+        mocker.patch(
+            "opensyndrome.ontology._search_ols", return_value={"Fever": "HP:0001945"}
+        )
         criterion = {"type": "symptom", "name": "Fever"}
         enrich_definition({"inclusion_criteria": [criterion]})
         assert criterion["ontology_id"] == "HP:0001945"
 
     def test_applies_mapping_to_exclusion_criteria(self, mocker):
-        mocker.patch("opensyndrome.ontology._search_ols", return_value="HP:0000988")
+        mocker.patch(
+            "opensyndrome.ontology._search_ols", return_value={"Rash": "HP:0000988"}
+        )
         criterion = {"type": "symptom", "name": "Rash"}
         enrich_definition({"inclusion_criteria": [], "exclusion_criteria": [criterion]})
         assert criterion["ontology_id"] == "HP:0000988"
@@ -333,7 +409,9 @@ class TestEnrichDefinition:
         assert definition["@context"] == OPENSYNDROME_CONTEXT_URL
 
     def test_handles_none_exclusion_criteria(self, mocker):
-        mocker.patch("opensyndrome.ontology._search_ols", return_value="HP:0001945")
+        mocker.patch(
+            "opensyndrome.ontology._search_ols", return_value={"Fever": "HP:0001945"}
+        )
         definition = {
             "inclusion_criteria": [{"type": "symptom", "name": "Fever"}],
             "exclusion_criteria": None,
@@ -342,7 +420,9 @@ class TestEnrichDefinition:
         assert result["@context"] == OPENSYNDROME_CONTEXT_URL
 
     def test_calls_verbose_callback(self, mocker):
-        mocker.patch("opensyndrome.ontology._search_ols", return_value="HP:0001945")
+        mocker.patch(
+            "opensyndrome.ontology._search_ols", return_value={"Fever": "HP:0001945"}
+        )
         calls = []
         definition = {"inclusion_criteria": [{"type": "symptom", "name": "Fever"}]}
         enrich_definition(
@@ -352,18 +432,17 @@ class TestEnrichDefinition:
         assert calls == [("Fever", "HP:0001945")]
 
     def test_uses_correct_ontologies_per_type(self, mocker):
-        mock_search = mocker.patch(
-            "opensyndrome.ontology._search_ols", return_value=None
-        )
+        mock_search = mocker.patch("opensyndrome.ontology._search_ols", return_value={})
         enrich_definition(
             {"inclusion_criteria": [{"type": "diagnosis", "name": "Dengue"}]}
         )
-        _, ontologies = mock_search.call_args.args
-        assert ontologies == ["mondo", "efo"]
+        queries = mock_search.call_args.args[0]
+        assert queries == {"Dengue": ["mondo", "efo"]}
 
     def test_uses_text2term_mapper(self, mocker):
         mock_search = mocker.patch(
-            "opensyndrome.ontology._search_text2term", return_value="HP:0001945"
+            "opensyndrome.ontology._search_text2term",
+            return_value={"Fever": "HP:0001945"},
         )
         criterion = {"type": "symptom", "name": "Fever"}
         enrich_definition({"inclusion_criteria": [criterion]}, mapper="text2term")
@@ -373,3 +452,22 @@ class TestEnrichDefinition:
     def test_invalid_mapper_raises(self):
         with pytest.raises(ValueError, match="Unknown mapper"):
             enrich_definition({"inclusion_criteria": []}, mapper="unknown")
+
+    def test_duplicate_names_last_criterion_type_wins(self, mocker):
+        """Contract: when the same name appears under different criterion types,
+        the LAST occurrence's ontology preference is queried, and the resulting
+        CURIE is applied to every occurrence."""
+        mock_search = mocker.patch(
+            "opensyndrome.ontology._search_ols",
+            return_value={"Fever": "EFO:0009088"},
+        )
+        inclusion = [
+            {"type": "symptom", "name": "Fever"},
+            {"type": "diagnosis", "name": "Fever"},
+        ]
+        enrich_definition({"inclusion_criteria": inclusion})
+
+        queries = mock_search.call_args.args[0]
+        assert queries == {"Fever": ["mondo", "efo"]}
+        assert inclusion[0]["ontology_id"] == "EFO:0009088"
+        assert inclusion[1]["ontology_id"] == "EFO:0009088"

--- a/tests/test_ontology.py
+++ b/tests/test_ontology.py
@@ -104,6 +104,13 @@ class TestApplyMapping:
         _apply_mapping(criteria, {"Fever": "HP:0001945"})
         assert child["ontology_id"] == "HP:0001945"
 
+    def test_skips_container_types(self):
+        child = {"type": "symptom", "name": "Fever"}
+        container = {"type": "criterion", "name": "Fever", "values": [child]}
+        _apply_mapping([container], {"Fever": "HP:0001945"})
+        assert "ontology_id" not in container
+        assert child["ontology_id"] == "HP:0001945"
+
 
 class TestPickBest:
     def test_exact_match_wins(self):
@@ -122,9 +129,9 @@ class TestPickBest:
         docs = [{"label": "Something", "short_form": "HP_0001945", "score": 1.0}]
         assert _pick_best(docs, "other") is None
 
-    def test_none_score_is_accepted(self):
+    def test_none_score_returns_none(self):
         docs = [{"label": "Skin rash", "short_form": "HP_0000988", "score": None}]
-        assert _pick_best(docs, "other") == "HP:0000988"
+        assert _pick_best(docs, "other") is None
 
     def test_empty_docs_returns_none(self):
         assert _pick_best([], "Fever") is None

--- a/tests/test_ontology.py
+++ b/tests/test_ontology.py
@@ -1,13 +1,17 @@
+import sys
 from unittest.mock import MagicMock, patch
 
+import pytest
 import requests
 
 from opensyndrome.ontology import (
     OPENSYNDROME_CONTEXT_URL,
     _apply_mapping,
     _collect_enrichable,
+    _iri_to_curie,
     _pick_best,
     _search_ols,
+    _search_text2term,
     enrich_definition,
 )
 
@@ -21,6 +25,93 @@ def _ols_response(label: str, short_form: str, score: float = 10.0) -> MagicMock
         }
     }
     return mock
+
+
+class TestIriToCurie:
+    def test_obo_iri(self):
+        assert (
+            _iri_to_curie("http://purl.obolibrary.org/obo/HP_0001945") == "HP:0001945"
+        )
+
+    def test_efo_iri(self):
+        assert _iri_to_curie("http://www.ebi.ac.uk/efo/EFO_0003900") == "EFO:0003900"
+
+    def test_mondo_iri(self):
+        assert (
+            _iri_to_curie("http://purl.obolibrary.org/obo/MONDO_0005148")
+            == "MONDO:0005148"
+        )
+
+
+def _make_text2term_module(map_terms_return=None, map_terms_side_effect=None):
+    """Build a fake text2term module for injection into sys.modules."""
+    fake = MagicMock()
+    if map_terms_side_effect is not None:
+        fake.map_terms.side_effect = map_terms_side_effect
+    else:
+        fake.map_terms.return_value = map_terms_return
+    return fake
+
+
+class _FakeDF:
+    """Minimal DataFrame stand-in for text2term output."""
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    @property
+    def empty(self):
+        return len(self._rows) == 0
+
+    @property
+    def iloc(self):
+        return self._rows
+
+
+_EMPTY_DF = _FakeDF([])
+
+
+def _ols_df(iri: str, score: float = 0.9) -> _FakeDF:
+    return _FakeDF([{"Mapped Term IRI": iri, "Mapping Score": score}])
+
+
+class TestSearchText2term:
+    @pytest.fixture(autouse=True)
+    def inject_text2term(self, request):
+        """Ensure text2term is removed from sys.modules between tests."""
+        sys.modules.pop("text2term", None)
+        yield
+        sys.modules.pop("text2term", None)
+
+    def test_returns_curie_on_match(self):
+        sys.modules["text2term"] = _make_text2term_module(
+            map_terms_return=_ols_df("http://purl.obolibrary.org/obo/HP_0001945")
+        )
+        assert _search_text2term("Fever", ["hp"]) == "HP:0001945"
+
+    def test_tries_next_ontology_on_empty(self):
+        sys.modules["text2term"] = _make_text2term_module(
+            map_terms_side_effect=[
+                _EMPTY_DF,
+                _ols_df("http://purl.obolibrary.org/obo/MONDO_0005148"),
+            ]
+        )
+        assert _search_text2term("Dengue", ["hp", "mondo"]) == "MONDO:0005148"
+
+    def test_returns_none_when_all_empty(self):
+        sys.modules["text2term"] = _make_text2term_module(map_terms_return=_EMPTY_DF)
+        assert _search_text2term("Unknown", ["hp"]) is None
+
+    def test_returns_none_on_exception(self):
+        sys.modules["text2term"] = _make_text2term_module(
+            map_terms_side_effect=Exception("network error")
+        )
+        assert _search_text2term("Fever", ["hp"]) is None
+
+    def test_raises_on_missing_library(self):
+        sys.modules["text2term"] = None
+        with pytest.raises(ImportError, match="text2term is not installed"):
+            _search_text2term("Fever", ["hp"])
 
 
 class TestCollectEnrichable:
@@ -247,3 +338,16 @@ class TestEnrichDefinition:
         )
         _, ontologies = mock_search.call_args.args
         assert ontologies == ["mondo", "efo"]
+
+    def test_uses_text2term_mapper(self, mocker):
+        mock_search = mocker.patch(
+            "opensyndrome.ontology._search_text2term", return_value="HP:0001945"
+        )
+        criterion = {"type": "symptom", "name": "Fever"}
+        enrich_definition({"inclusion_criteria": [criterion]}, mapper="text2term")
+        mock_search.assert_called_once()
+        assert criterion["ontology_id"] == "HP:0001945"
+
+    def test_invalid_mapper_raises(self):
+        with pytest.raises(ValueError, match="Unknown mapper"):
+            enrich_definition({"inclusion_criteria": []}, mapper="unknown")

--- a/tests/test_ontology.py
+++ b/tests/test_ontology.py
@@ -1,0 +1,242 @@
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from opensyndrome.ontology import (
+    OPENSYNDROME_CONTEXT_URL,
+    _apply_mapping,
+    _collect_enrichable,
+    _pick_best,
+    _search_ols,
+    enrich_definition,
+)
+
+
+def _ols_response(label: str, short_form: str, score: float = 10.0) -> MagicMock:
+    mock = MagicMock()
+    mock.raise_for_status = MagicMock()
+    mock.json.return_value = {
+        "response": {
+            "docs": [{"label": label, "short_form": short_form, "score": score}]
+        }
+    }
+    return mock
+
+
+class TestCollectEnrichable:
+    def test_collects_enrichable_criterion(self):
+        criteria = [{"type": "symptom", "name": "Fever"}]
+        assert _collect_enrichable(criteria) == criteria
+
+    def test_skips_criterion_type(self):
+        assert _collect_enrichable([{"type": "criterion", "name": "Group"}]) == []
+
+    def test_skips_demographic_criteria_type(self):
+        assert (
+            _collect_enrichable([{"type": "demographic_criteria", "name": "Age"}]) == []
+        )
+
+    def test_skips_existing_ontology_id(self):
+        criteria = [{"type": "symptom", "name": "Fever", "ontology_id": "HP:0001945"}]
+        assert _collect_enrichable(criteria) == []
+
+    def test_skips_missing_type(self):
+        assert _collect_enrichable([{"name": "Fever"}]) == []
+
+    def test_skips_empty_name(self):
+        assert _collect_enrichable([{"type": "symptom", "name": "   "}]) == []
+
+    def test_recurses_into_values(self):
+        child = {"type": "symptom", "name": "Fever"}
+        criteria = [{"type": "criterion", "name": "Group", "values": [child]}]
+        assert _collect_enrichable(criteria) == [child]
+
+    def test_container_children_collected_despite_skip(self):
+        child = {"type": "symptom", "name": "Rash"}
+        criteria = [
+            {"type": "demographic_criteria", "name": "Age group", "values": [child]}
+        ]
+        assert _collect_enrichable(criteria) == [child]
+
+    def test_collects_multiple_types(self):
+        criteria = [
+            {"type": "symptom", "name": "Fever"},
+            {"type": "diagnosis", "name": "Dengue"},
+            {"type": "diagnostic_test", "name": "PCR"},
+        ]
+        assert _collect_enrichable(criteria) == criteria
+
+
+class TestApplyMapping:
+    def test_sets_ontology_id(self):
+        criteria = [{"type": "symptom", "name": "Fever"}]
+        _apply_mapping(criteria, {"Fever": "HP:0001945"})
+        assert criteria[0]["ontology_id"] == "HP:0001945"
+
+    def test_unmatched_criteria_unchanged(self):
+        criteria = [{"type": "symptom", "name": "Rash"}]
+        _apply_mapping(criteria, {"Fever": "HP:0001945"})
+        assert "ontology_id" not in criteria[0]
+
+    def test_calls_verbose_callback(self):
+        calls = []
+        criteria = [{"type": "symptom", "name": "Fever"}]
+        _apply_mapping(
+            criteria,
+            {"Fever": "HP:0001945"},
+            verbose_callback=lambda n, c: calls.append((n, c)),
+        )
+        assert calls == [("Fever", "HP:0001945")]
+
+    def test_no_callback_when_no_match(self):
+        calls = []
+        criteria = [{"type": "symptom", "name": "Rash"}]
+        _apply_mapping(
+            criteria,
+            {"Fever": "HP:0001945"},
+            verbose_callback=lambda n, c: calls.append((n, c)),
+        )
+        assert calls == []
+
+    def test_recurses_into_values(self):
+        child = {"type": "symptom", "name": "Fever"}
+        criteria = [{"type": "criterion", "name": "Group", "values": [child]}]
+        _apply_mapping(criteria, {"Fever": "HP:0001945"})
+        assert child["ontology_id"] == "HP:0001945"
+
+
+class TestPickBest:
+    def test_exact_match_wins(self):
+        docs = [{"label": "Fever", "short_form": "HP_0001945", "score": 1.0}]
+        assert _pick_best(docs, "Fever") == "HP:0001945"
+
+    def test_exact_match_case_insensitive(self):
+        docs = [{"label": "Skin rash", "short_form": "HP_0000988", "score": 1.0}]
+        assert _pick_best(docs, "SKIN RASH") == "HP:0000988"
+
+    def test_score_threshold(self):
+        docs = [{"label": "Febrile", "short_form": "HP_0001945", "score": 6.0}]
+        assert _pick_best(docs, "other") == "HP:0001945"
+
+    def test_below_threshold_returns_none(self):
+        docs = [{"label": "Something", "short_form": "HP_0001945", "score": 1.0}]
+        assert _pick_best(docs, "other") is None
+
+    def test_none_score_is_accepted(self):
+        docs = [{"label": "Skin rash", "short_form": "HP_0000988", "score": None}]
+        assert _pick_best(docs, "other") == "HP:0000988"
+
+    def test_empty_docs_returns_none(self):
+        assert _pick_best([], "Fever") is None
+
+
+class TestSearchOls:
+    def test_returns_curie_on_exact_match(self):
+        with patch("opensyndrome.ontology.requests.get") as mock_get:
+            mock_get.return_value = _ols_response("Fever", "HP_0001945")
+            result = _search_ols("Fever", ["hp"])
+        assert result == "HP:0001945"
+
+    def test_returns_curie_on_score_threshold(self):
+        with patch("opensyndrome.ontology.requests.get") as mock_get:
+            mock_get.return_value = _ols_response("Febrile", "HP_0001945", score=6.0)
+            result = _search_ols("Febrile", ["hp"])
+        assert result == "HP:0001945"
+
+    def test_returns_none_below_threshold(self):
+        with patch("opensyndrome.ontology.requests.get") as mock_get:
+            mock_get.return_value = _ols_response("Unrelated", "HP_0001945", score=1.0)
+            result = _search_ols("Something else", ["hp"])
+        assert result is None
+
+    def test_returns_none_on_empty_docs(self):
+        with patch("opensyndrome.ontology.requests.get") as mock_get:
+            mock = MagicMock()
+            mock.raise_for_status = MagicMock()
+            mock.json.return_value = {"response": {"docs": []}}
+            mock_get.return_value = mock
+            result = _search_ols("Unknown term", ["hp"])
+        assert result is None
+
+    def test_falls_back_to_synonym_search(self):
+        no_match = MagicMock()
+        no_match.raise_for_status = MagicMock()
+        no_match.json.return_value = {"response": {"docs": []}}
+        synonym_hit = _ols_response("Skin rash", "HP_0000988", score=8.0)
+        with patch(
+            "opensyndrome.ontology.requests.get", side_effect=[no_match, synonym_hit]
+        ):
+            result = _search_ols("rash", ["hp"])
+        assert result == "HP:0000988"
+
+    def test_returns_none_on_request_exception(self):
+        with patch("opensyndrome.ontology.requests.get") as mock_get:
+            mock_get.side_effect = requests.RequestException("timeout")
+            result = _search_ols("Fever", ["hp"])
+        assert result is None
+
+    def test_normalizes_short_form(self):
+        with patch("opensyndrome.ontology.requests.get") as mock_get:
+            mock_get.return_value = _ols_response("Dengue fever", "MONDO_0005148")
+            result = _search_ols("Dengue fever", ["mondo"])
+        assert result == "MONDO:0005148"
+
+
+class TestEnrichDefinition:
+    def test_sets_context(self, mocker):
+        mocker.patch("opensyndrome.ontology._search_ols", return_value=None)
+        definition = {"inclusion_criteria": [{"type": "symptom", "name": "Fever"}]}
+        result = enrich_definition(definition)
+        assert result["@context"] == OPENSYNDROME_CONTEXT_URL
+
+    def test_applies_mapping_to_inclusion_criteria(self, mocker):
+        mocker.patch("opensyndrome.ontology._search_ols", return_value="HP:0001945")
+        criterion = {"type": "symptom", "name": "Fever"}
+        enrich_definition({"inclusion_criteria": [criterion]})
+        assert criterion["ontology_id"] == "HP:0001945"
+
+    def test_applies_mapping_to_exclusion_criteria(self, mocker):
+        mocker.patch("opensyndrome.ontology._search_ols", return_value="HP:0000988")
+        criterion = {"type": "symptom", "name": "Rash"}
+        enrich_definition({"inclusion_criteria": [], "exclusion_criteria": [criterion]})
+        assert criterion["ontology_id"] == "HP:0000988"
+
+    def test_no_enrichable_criteria_skips_search(self, mocker):
+        mock_search = mocker.patch("opensyndrome.ontology._search_ols")
+        enrich_definition({"inclusion_criteria": []})
+        mock_search.assert_not_called()
+
+    def test_sets_context_even_with_no_enrichable_criteria(self, mocker):
+        mocker.patch("opensyndrome.ontology._search_ols")
+        definition = {"inclusion_criteria": []}
+        enrich_definition(definition)
+        assert definition["@context"] == OPENSYNDROME_CONTEXT_URL
+
+    def test_handles_none_exclusion_criteria(self, mocker):
+        mocker.patch("opensyndrome.ontology._search_ols", return_value="HP:0001945")
+        definition = {
+            "inclusion_criteria": [{"type": "symptom", "name": "Fever"}],
+            "exclusion_criteria": None,
+        }
+        result = enrich_definition(definition)
+        assert result["@context"] == OPENSYNDROME_CONTEXT_URL
+
+    def test_calls_verbose_callback(self, mocker):
+        mocker.patch("opensyndrome.ontology._search_ols", return_value="HP:0001945")
+        calls = []
+        definition = {"inclusion_criteria": [{"type": "symptom", "name": "Fever"}]}
+        enrich_definition(
+            definition,
+            verbose_callback=lambda n, c: calls.append((n, c)),
+        )
+        assert calls == [("Fever", "HP:0001945")]
+
+    def test_uses_correct_ontologies_per_type(self, mocker):
+        mock_search = mocker.patch(
+            "opensyndrome.ontology._search_ols", return_value=None
+        )
+        enrich_definition(
+            {"inclusion_criteria": [{"type": "diagnosis", "name": "Dengue"}]}
+        )
+        _, ontologies = mock_search.call_args.args
+        assert ontologies == ["mondo", "efo"]

--- a/tests/test_ontology.py
+++ b/tests/test_ontology.py
@@ -16,18 +16,19 @@ from opensyndrome.ontology import (
 )
 
 
-def _ols_response(label: str, short_form: str, score: float = 10.0) -> MagicMock:
-    mock = MagicMock()
-    mock.raise_for_status = MagicMock()
-    mock.json.return_value = {
-        "response": {
-            "docs": [{"label": label, "short_form": short_form, "score": score}]
-        }
-    }
-    return mock
+def _ols_doc(label: str, obo_id: str) -> dict:
+    return {"label": label, "obo_id": obo_id}
+
+
+def _ols_payload(docs: list[dict]) -> dict:
+    return {"response": {"docs": docs}}
 
 
 class TestIriToCurie:
+    @pytest.fixture(autouse=True)
+    def _require_bioregistry(self):
+        pytest.importorskip("bioregistry")
+
     def test_obo_iri(self):
         assert (
             _iri_to_curie("http://purl.obolibrary.org/obo/HP_0001945") == "HP:0001945"
@@ -42,10 +43,24 @@ class TestIriToCurie:
             == "MONDO:0005148"
         )
 
+    def test_unparseable_iri_returns_none(self):
+        assert _iri_to_curie("garbage://nonsense") is None
+
+    def test_loinc_native_namespace_uppercased(self):
+        assert _iri_to_curie("https://loinc.org/2345-7") == "LOINC:2345-7"
+
+    def test_unknown_prefix_returns_none(self):
+        assert _iri_to_curie("http://purl.obolibrary.org/obo/UNKNOWNXYZ_42") is None
+
 
 def _make_text2term_module(map_terms_return=None, map_terms_side_effect=None):
-    """Build a fake text2term module for injection into sys.modules."""
-    fake = MagicMock()
+    """Build a fake text2term module for injection into sys.modules.
+
+    Uses spec=real text2term so attribute access fails fast on API drift.
+    """
+    import text2term as real_text2term
+
+    fake = MagicMock(spec=real_text2term)
     if map_terms_side_effect is not None:
         fake.map_terms.side_effect = map_terms_side_effect
     else:
@@ -77,6 +92,10 @@ def _ols_df(iri: str, score: float = 0.9) -> _FakeDF:
 
 class TestSearchText2term:
     @pytest.fixture(autouse=True)
+    def _require_bioregistry(self):
+        pytest.importorskip("bioregistry")
+
+    @pytest.fixture(autouse=True)
     def inject_text2term(self, request):
         """Ensure text2term is removed from sys.modules between tests."""
         sys.modules.pop("text2term", None)
@@ -102,11 +121,27 @@ class TestSearchText2term:
         sys.modules["text2term"] = _make_text2term_module(map_terms_return=_EMPTY_DF)
         assert _search_text2term("Unknown", ["hp"]) is None
 
-    def test_returns_none_on_exception(self):
+    def test_returns_none_on_request_exception(self):
         sys.modules["text2term"] = _make_text2term_module(
-            map_terms_side_effect=Exception("network error")
+            map_terms_side_effect=requests.RequestException("network error")
         )
         assert _search_text2term("Fever", ["hp"]) is None
+
+    def test_unexpected_exception_propagates(self):
+        sys.modules["text2term"] = _make_text2term_module(
+            map_terms_side_effect=AttributeError("bug in text2term")
+        )
+        with pytest.raises(AttributeError, match="bug in text2term"):
+            _search_text2term("Fever", ["hp"])
+
+    def test_unparseable_iri_falls_through_to_next_ontology(self):
+        sys.modules["text2term"] = _make_text2term_module(
+            map_terms_side_effect=[
+                _ols_df("garbage://nonsense"),
+                _ols_df("http://purl.obolibrary.org/obo/MONDO_0005148"),
+            ]
+        )
+        assert _search_text2term("Dengue", ["hp", "mondo"]) == "MONDO:0005148"
 
     def test_raises_on_missing_library(self):
         sys.modules["text2term"] = None
@@ -205,23 +240,15 @@ class TestApplyMapping:
 
 class TestPickBest:
     def test_exact_match_wins(self):
-        docs = [{"label": "Fever", "short_form": "HP_0001945", "score": 1.0}]
+        docs = [_ols_doc("Fever", "HP:0001945")]
         assert _pick_best(docs, "Fever") == "HP:0001945"
 
     def test_exact_match_case_insensitive(self):
-        docs = [{"label": "Skin rash", "short_form": "HP_0000988", "score": 1.0}]
+        docs = [_ols_doc("Skin rash", "HP:0000988")]
         assert _pick_best(docs, "SKIN RASH") == "HP:0000988"
 
-    def test_score_threshold(self):
-        docs = [{"label": "Febrile", "short_form": "HP_0001945", "score": 6.0}]
-        assert _pick_best(docs, "other") == "HP:0001945"
-
-    def test_below_threshold_returns_none(self):
-        docs = [{"label": "Something", "short_form": "HP_0001945", "score": 1.0}]
-        assert _pick_best(docs, "other") is None
-
-    def test_none_score_returns_none(self):
-        docs = [{"label": "Skin rash", "short_form": "HP_0000988", "score": None}]
+    def test_no_match_returns_none(self):
+        docs = [_ols_doc("Febrile", "HP:0001945")]
         assert _pick_best(docs, "other") is None
 
     def test_empty_docs_returns_none(self):
@@ -230,54 +257,49 @@ class TestPickBest:
 
 class TestSearchOls:
     def test_returns_curie_on_exact_match(self):
-        with patch("opensyndrome.ontology.requests.get") as mock_get:
-            mock_get.return_value = _ols_response("Fever", "HP_0001945")
+        with patch("opensyndrome.ontology.ols.get_json") as mock_get:
+            mock_get.return_value = _ols_payload([_ols_doc("Fever", "HP:0001945")])
             result = _search_ols("Fever", ["hp"])
         assert result == "HP:0001945"
 
-    def test_returns_curie_on_score_threshold(self):
-        with patch("opensyndrome.ontology.requests.get") as mock_get:
-            mock_get.return_value = _ols_response("Febrile", "HP_0001945", score=6.0)
-            result = _search_ols("Febrile", ["hp"])
-        assert result == "HP:0001945"
-
-    def test_returns_none_below_threshold(self):
-        with patch("opensyndrome.ontology.requests.get") as mock_get:
-            mock_get.return_value = _ols_response("Unrelated", "HP_0001945", score=1.0)
-            result = _search_ols("Something else", ["hp"])
-        assert result is None
-
     def test_returns_none_on_empty_docs(self):
-        with patch("opensyndrome.ontology.requests.get") as mock_get:
-            mock = MagicMock()
-            mock.raise_for_status = MagicMock()
-            mock.json.return_value = {"response": {"docs": []}}
-            mock_get.return_value = mock
+        with patch("opensyndrome.ontology.ols.get_json") as mock_get:
+            mock_get.return_value = _ols_payload([])
             result = _search_ols("Unknown term", ["hp"])
         assert result is None
 
     def test_falls_back_to_synonym_search(self):
-        no_match = MagicMock()
-        no_match.raise_for_status = MagicMock()
-        no_match.json.return_value = {"response": {"docs": []}}
-        synonym_hit = _ols_response("Skin rash", "HP_0000988", score=8.0)
+        synonym_hit = _ols_payload([_ols_doc("rash", "HP:0000988")])
         with patch(
-            "opensyndrome.ontology.requests.get", side_effect=[no_match, synonym_hit]
-        ):
+            "opensyndrome.ontology.ols.get_json",
+            side_effect=[_ols_payload([]), synonym_hit],
+        ) as mock_get:
             result = _search_ols("rash", ["hp"])
         assert result == "HP:0000988"
+        assert mock_get.call_count == 2
+        assert mock_get.call_args_list[1].kwargs["params"]["queryFields"] == (
+            "label,synonym"
+        )
 
     def test_returns_none_on_request_exception(self):
-        with patch("opensyndrome.ontology.requests.get") as mock_get:
+        with patch("opensyndrome.ontology.ols.get_json") as mock_get:
             mock_get.side_effect = requests.RequestException("timeout")
             result = _search_ols("Fever", ["hp"])
         assert result is None
 
-    def test_normalizes_short_form(self):
-        with patch("opensyndrome.ontology.requests.get") as mock_get:
-            mock_get.return_value = _ols_response("Dengue fever", "MONDO_0005148")
-            result = _search_ols("Dengue fever", ["mondo"])
-        assert result == "MONDO:0005148"
+    def test_passes_ontology_filter_to_client(self):
+        with patch("opensyndrome.ontology.ols.get_json") as mock_get:
+            mock_get.return_value = _ols_payload([])
+            _search_ols("Fever", ["hp", "mondo"])
+        params = mock_get.call_args.kwargs["params"]
+        assert params["ontology"] == "hp,mondo"
+        assert params["type"] == "class"
+
+    def test_passes_explicit_timeout_to_client(self):
+        with patch("opensyndrome.ontology.ols.get_json") as mock_get:
+            mock_get.return_value = _ols_payload([])
+            _search_ols("Fever", ["hp"], timeout=15)
+        assert mock_get.call_args.kwargs["timeout"] == 15
 
 
 class TestEnrichDefinition:

--- a/uv.lock
+++ b/uv.lock
@@ -114,6 +114,15 @@ wheels = [
 ]
 
 [[package]]
+name = "alabaster"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/f8/d9c74d0daf3f742840fd818d69cfae176fa332022fd44e3469487d5a9420/alabaster-1.0.0.tar.gz", hash = "sha256:c00dca57bca26fa62a6d7d0a9fcce65f3e026e9bfe33e9c538fd3fbb2144fd9e", size = 24210, upload-time = "2024-07-26T18:15:03.762Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/b3/6b4067be973ae96ba0d615946e314c5ae35f9f993eca561b356540bb0c2b/alabaster-1.0.0-py3-none-any.whl", hash = "sha256:fc6786402dc3fcb2de3cabd5fe455a2db534b371124f1f21de8731783dec828b", size = 13929, upload-time = "2024-07-26T18:15:02.05Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -155,12 +164,49 @@ wheels = [
 ]
 
 [[package]]
+name = "argparse"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/dd/e617cfc3f6210ae183374cd9f6a26b20514bbb5a792af97949c5aacddf0f/argparse-1.4.0.tar.gz", hash = "sha256:62b089a55be1d8949cd2bc7e0df0bddb9e028faefc8c32038cc84862aefdd6e4", size = 70508, upload-time = "2015-09-12T20:22:16.217Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/94/3af39d34be01a24a6e65433d19e107099374224905f1e0cc6bbe1fd22a2f/argparse-1.4.0-py2.py3-none-any.whl", hash = "sha256:c31647edb69fd3d465a847ea3157d37bed1f95f19760b11a47aa91c04b666314", size = 23000, upload-time = "2015-09-14T16:03:16.137Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/49/7c/fdf464bcc51d23881d110abd74b512a42b3d5d376a55a831b44c603ae17f/attrs-25.1.0.tar.gz", hash = "sha256:1c97078a80c814273a76b2a298a932eb681c87415c11dee0a6921de7f1b02c3e", size = 810562, upload-time = "2025-01-25T11:30:12.508Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fc/30/d4986a882011f9df997a55e6becd864812ccfcd821d64aac8570ee39f719/attrs-25.1.0-py3-none-any.whl", hash = "sha256:c75a69e28a550a7e93789579c22aa26b0f5b83b75dc4e08fe092980051e1090a", size = 63152, upload-time = "2025-01-25T11:30:10.164Z" },
+]
+
+[[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
+name = "bioregistry"
+version = "0.11.35"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "curies" },
+    { name = "more-click" },
+    { name = "pydantic", version = "2.10.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "pystow" },
+    { name = "requests" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/f2/f1e162bda13c762fa8ac2b20139af61181cf8c0aee70fb1ebf380f280829/bioregistry-0.11.35.tar.gz", hash = "sha256:f3c57638c193161674f3569312dd6c3a3f99ace862a5c8e0c7986c06e30815d0", size = 6119956, upload-time = "2025-01-28T09:40:56.726Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/ab/8441327ba6f941519b33209736783e9b733f2532dbdfcdaa7feee828b910/bioregistry-0.11.35-py3-none-any.whl", hash = "sha256:64713a6595190175d506f2053b1599707a8cf266a2ba44cff3c2e29b71063f90", size = 5303598, upload-time = "2025-01-28T09:40:49.538Z" },
 ]
 
 [[package]]
@@ -277,6 +323,21 @@ wheels = [
 ]
 
 [[package]]
+name = "curies"
+version = "0.12.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic", version = "2.10.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "pydantic", version = "2.12.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/30/24ee7cef5e2c0cc9c70bc50a0929014e22d31ca5ebeebf806a276053c378/curies-0.12.10.tar.gz", hash = "sha256:5bad4111b719ff79a84bc362fab9cbc992325e2bc6dfeca249813d0c5c2ba6c5", size = 375216, upload-time = "2026-03-16T08:27:03.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/7d/7363c69b8609ad14c333eca693a55bd0cfc11f218c5e71d6b1ce948d2c0d/curies-0.12.10-py3-none-any.whl", hash = "sha256:b7177d1ee9dfd5257fb8dfbe8dea5e3c43507b36e0ebf0bcc01e8fdd5d5ed221", size = 70370, upload-time = "2026-03-16T08:27:04.999Z" },
+]
+
+[[package]]
 name = "datamodel-code-generator"
 version = "0.55.0"
 source = { registry = "https://pypi.org/simple" }
@@ -330,6 +391,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.21.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/ed/aefcc8cd0ba62a0560c3c18c33925362d46c6075480bfa4df87b28e169a9/docutils-0.21.2.tar.gz", hash = "sha256:3a6b18732edf182daa3cd12775bbb338cf5691468f91eeeb109deff6ebfa986f", size = 2204444, upload-time = "2024-04-23T18:57:18.24Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/d7/9322c609343d929e75e7e5e6255e614fcc67572cfd083959cdef3b7aad79/docutils-0.21.2-py3-none-any.whl", hash = "sha256:dafca5b9e384f0e419294eb4d2ff9fa826435bf15f15b7bd45723e8ad76811b2", size = 587408, upload-time = "2024-04-23T18:57:14.835Z" },
 ]
 
 [[package]]
@@ -481,6 +551,24 @@ wheels = [
 ]
 
 [[package]]
+name = "gensim"
+version = "4.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "smart-open" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ec/bc/36ce4d510085cf150f17d79bb5e88cde942aeba2a894aed5893812ea1e6d/gensim-4.3.3.tar.gz", hash = "sha256:84852076a6a3d88d7dac5be245e24c21c3b819b565e14c1b61fa3e5ee76dcf57", size = 23258708, upload-time = "2024-07-19T14:42:35.418Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/f1/3231b3fd6f7424f28d7d673679c843da0c61659538262a234f9f43ed5b10/gensim-4.3.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:9a65ed1a8c1fc83890b4eb2a45ae2b32e82a0209c970c8c74694d0374c2415cb", size = 24079041, upload-time = "2024-07-19T14:40:40.907Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/76/616bc781bc19ee76b387a101211f73e00cf59368fcc221e77f88ea907d04/gensim-4.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4db485e08a0287e0fd6a029d89b90913d1df38f1dcd34cd2ab758873ba9255f3", size = 24035496, upload-time = "2024-07-19T14:40:47.667Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/b7/a316ba52548ca405413c23967c1c6c77d00f82cf6b0cb63d268001e023aa/gensim-4.3.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7198987116373ab99f034b292a04ac841531d12b56345851c98b40a3fcd93a85", size = 26487104, upload-time = "2024-07-19T14:40:54.867Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/07/7a0d5e6cab4da2769c8018f2472690ccb8cab191bf2fe46342dfd627486b/gensim-4.3.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6237a50de4da7a037b19b2b6c430b6537243dcdedebf94afeb089e951953e601", size = 26606101, upload-time = "2024-07-19T14:41:02.539Z" },
+    { url = "https://files.pythonhosted.org/packages/79/7b/747fcb06280764cf20353361162eff68c6b0a3be34c43ead5ae393d3b18e/gensim-4.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:c910c2d5a71f532273166a3a82762959973f0513b221a495fa5a2a07652ee66d", size = 24009244, upload-time = "2024-07-19T14:41:09.732Z" },
+]
+
+[[package]]
 name = "genson"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -593,6 +681,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+]
+
+[[package]]
+name = "imagesize"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/e6/7bf14eeb8f8b7251141944835abd42eb20a658d89084b7e1f3e5fe394090/imagesize-2.0.0.tar.gz", hash = "sha256:8e8358c4a05c304f1fccf7ff96f036e7243a189e9e42e90851993c558cfe9ee3", size = 1773045, upload-time = "2026-03-03T14:18:29.941Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/53/fb7122b71361a0d121b669dcf3d31244ef75badbbb724af388948de543e2/imagesize-2.0.0-py2.py3-none-any.whl", hash = "sha256:5667c5bbb57ab3f1fa4bc366f4fbc971db3d5ed011fd2715fd8001f782718d96", size = 9441, upload-time = "2026-03-03T14:18:27.892Z" },
 ]
 
 [[package]]
@@ -745,6 +842,15 @@ wheels = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.23.0"
 source = { registry = "https://pypi.org/simple" }
@@ -797,14 +903,14 @@ wheels = [
 
 [[package]]
 name = "markdown-it-py"
-version = "4.0.0"
+version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mdurl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
 ]
 
 [[package]]
@@ -871,12 +977,36 @@ wheels = [
 ]
 
 [[package]]
+name = "mdit-py-plugins"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/fd/a756d36c0bfba5f6e39a1cdbdbfdd448dc02692467d83816dff4592a1ebc/mdit_py_plugins-0.5.0.tar.gz", hash = "sha256:f4918cb50119f50446560513a8e311d574ff6aaed72606ddae6d35716fe809c6", size = 44655, upload-time = "2025-08-11T07:25:49.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl", hash = "sha256:07a08422fc1936a5d26d146759e9155ea466e842f5ab2f7d2266dd084c8dab1f", size = 57205, upload-time = "2025-08-11T07:25:47.597Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "more-click"
+version = "0.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/52/dc524f10307c472f3ee83ceef5cc3c3c1d987f9554c90cf34616bdcb2ca9/more_click-0.1.3.tar.gz", hash = "sha256:c170987d37334278169fe3b9b388f1fcd9fc96439579354fd7c537537a182128", size = 11793, upload-time = "2025-10-21T15:28:23.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/c8/62a253fdb3f66529ed0d7f0e4703fdb44cc8745610f199e173550d8f85eb/more_click-0.1.3-py3-none-any.whl", hash = "sha256:12f0f3da94c84d39daaaec08e9503df8877f493812f8ebc3f0713081da48d282", size = 12052, upload-time = "2025-10-21T15:28:22.456Z" },
 ]
 
 [[package]]
@@ -997,6 +1127,38 @@ wheels = [
 ]
 
 [[package]]
+name = "myst-parser"
+version = "4.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "jinja2" },
+    { name = "markdown-it-py" },
+    { name = "mdit-py-plugins" },
+    { name = "pyyaml" },
+    { name = "sphinx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/a5/9626ba4f73555b3735ad86247a8077d4603aa8628537687c839ab08bfe44/myst_parser-4.0.1.tar.gz", hash = "sha256:5cfea715e4f3574138aecbf7d54132296bfd72bb614d31168f48c477a830a7c4", size = 93985, upload-time = "2025-02-12T10:53:03.833Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/df/76d0321c3797b54b60fef9ec3bd6f4cfd124b9e422182156a1dd418722cf/myst_parser-4.0.1-py3-none-any.whl", hash = "sha256:9134e88959ec3b5780aedf8a99680ea242869d012e8821db3126d427edc9c95d", size = 84579, upload-time = "2025-02-12T10:53:02.078Z" },
+]
+
+[[package]]
+name = "nltk"
+version = "3.9.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "joblib" },
+    { name = "regex" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/8f/915e1c12df07c70ed779d18ab83d065718a926e70d3ea33eb0cd66ffb7c0/nltk-3.9.3.tar.gz", hash = "sha256:cb5945d6424a98d694c2b9a0264519fab4363711065a46aa0ae7a2195b92e71f", size = 2923673, upload-time = "2026-02-24T12:05:53.833Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/7e/9af5a710a1236e4772de8dfcc6af942a561327bb9f42b5b4a24d0cf100fd/nltk-3.9.3-py3-none-any.whl", hash = "sha256:60b3db6e9995b3dd976b1f0fa7dec22069b2677e759c28eb69b62ddd44870522", size = 1525385, upload-time = "2026-02-24T12:05:46.54Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1007,43 +1169,18 @@ wheels = [
 
 [[package]]
 name = "numpy"
-version = "2.3.1"
+version = "1.26.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2e/19/d7c972dfe90a353dbd3efbbe1d14a5951de80c99c9dc1b93cd998d51dc0f/numpy-2.3.1.tar.gz", hash = "sha256:1ec9ae20a4226da374362cca3c62cd753faf2f951440b0e3b98e93c235441d2b", size = 20390372, upload-time = "2025-06-21T12:28:33.469Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/6e/09db70a523a96d25e115e71cc56a6f9031e7b8cd166c1ac8438307c14058/numpy-1.26.4.tar.gz", hash = "sha256:2a02aba9ed12e4ac4eb3ea9421c420301a0c6460d9830d74a9df87efa4912010", size = 15786129, upload-time = "2024-02-06T00:26:44.495Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/56/71ad5022e2f63cfe0ca93559403d0edef14aea70a841d640bd13cdba578e/numpy-2.3.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2959d8f268f3d8ee402b04a9ec4bb7604555aeacf78b360dc4ec27f1d508177d", size = 20896664, upload-time = "2025-06-21T12:15:30.845Z" },
-    { url = "https://files.pythonhosted.org/packages/25/65/2db52ba049813670f7f987cc5db6dac9be7cd95e923cc6832b3d32d87cef/numpy-2.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:762e0c0c6b56bdedfef9a8e1d4538556438288c4276901ea008ae44091954e29", size = 14131078, upload-time = "2025-06-21T12:15:52.23Z" },
-    { url = "https://files.pythonhosted.org/packages/57/dd/28fa3c17b0e751047ac928c1e1b6990238faad76e9b147e585b573d9d1bd/numpy-2.3.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:867ef172a0976aaa1f1d1b63cf2090de8b636a7674607d514505fb7276ab08fc", size = 5112554, upload-time = "2025-06-21T12:16:01.434Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/fc/84ea0cba8e760c4644b708b6819d91784c290288c27aca916115e3311d17/numpy-2.3.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:4e602e1b8682c2b833af89ba641ad4176053aaa50f5cacda1a27004352dde943", size = 6646560, upload-time = "2025-06-21T12:16:11.895Z" },
-    { url = "https://files.pythonhosted.org/packages/61/b2/512b0c2ddec985ad1e496b0bd853eeb572315c0f07cd6997473ced8f15e2/numpy-2.3.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:8e333040d069eba1652fb08962ec5b76af7f2c7bce1df7e1418c8055cf776f25", size = 14260638, upload-time = "2025-06-21T12:16:32.611Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/45/c51cb248e679a6c6ab14b7a8e3ead3f4a3fe7425fc7a6f98b3f147bec532/numpy-2.3.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:e7cbf5a5eafd8d230a3ce356d892512185230e4781a361229bd902ff403bc660", size = 16632729, upload-time = "2025-06-21T12:16:57.439Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/ff/feb4be2e5c09a3da161b412019caf47183099cbea1132fd98061808c2df2/numpy-2.3.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5f1b8f26d1086835f442286c1d9b64bb3974b0b1e41bb105358fd07d20872952", size = 15565330, upload-time = "2025-06-21T12:17:20.638Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/6d/ceafe87587101e9ab0d370e4f6e5f3f3a85b9a697f2318738e5e7e176ce3/numpy-2.3.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ee8340cb48c9b7a5899d1149eece41ca535513a9698098edbade2a8e7a84da77", size = 18361734, upload-time = "2025-06-21T12:17:47.938Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/19/0fb49a3ea088be691f040c9bf1817e4669a339d6e98579f91859b902c636/numpy-2.3.1-cp312-cp312-win32.whl", hash = "sha256:e772dda20a6002ef7061713dc1e2585bc1b534e7909b2030b5a46dae8ff077ab", size = 6320411, upload-time = "2025-06-21T12:17:58.475Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/3e/e28f4c1dd9e042eb57a3eb652f200225e311b608632bc727ae378623d4f8/numpy-2.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:cfecc7822543abdea6de08758091da655ea2210b8ffa1faf116b940693d3df76", size = 12734973, upload-time = "2025-06-21T12:18:17.601Z" },
-    { url = "https://files.pythonhosted.org/packages/04/a8/8a5e9079dc722acf53522b8f8842e79541ea81835e9b5483388701421073/numpy-2.3.1-cp312-cp312-win_arm64.whl", hash = "sha256:7be91b2239af2658653c5bb6f1b8bccafaf08226a258caf78ce44710a0160d30", size = 10191491, upload-time = "2025-06-21T12:18:33.585Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/bd/35ad97006d8abff8631293f8ea6adf07b0108ce6fec68da3c3fcca1197f2/numpy-2.3.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:25a1992b0a3fdcdaec9f552ef10d8103186f5397ab45e2d25f8ac51b1a6b97e8", size = 20889381, upload-time = "2025-06-21T12:19:04.103Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/4f/df5923874d8095b6062495b39729178eef4a922119cee32a12ee1bd4664c/numpy-2.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7dea630156d39b02a63c18f508f85010230409db5b2927ba59c8ba4ab3e8272e", size = 14152726, upload-time = "2025-06-21T12:19:25.599Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/0f/a1f269b125806212a876f7efb049b06c6f8772cf0121139f97774cd95626/numpy-2.3.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:bada6058dd886061f10ea15f230ccf7dfff40572e99fef440a4a857c8728c9c0", size = 5105145, upload-time = "2025-06-21T12:19:34.782Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/63/a7f7fd5f375b0361682f6ffbf686787e82b7bbd561268e4f30afad2bb3c0/numpy-2.3.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:a894f3816eb17b29e4783e5873f92faf55b710c2519e5c351767c51f79d8526d", size = 6639409, upload-time = "2025-06-21T12:19:45.228Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/0d/1854a4121af895aab383f4aa233748f1df4671ef331d898e32426756a8a6/numpy-2.3.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:18703df6c4a4fee55fd3d6e5a253d01c5d33a295409b03fda0c86b3ca2ff41a1", size = 14257630, upload-time = "2025-06-21T12:20:06.544Z" },
-    { url = "https://files.pythonhosted.org/packages/50/30/af1b277b443f2fb08acf1c55ce9d68ee540043f158630d62cef012750f9f/numpy-2.3.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5902660491bd7a48b2ec16c23ccb9124b8abfd9583c5fdfa123fe6b421e03de1", size = 16627546, upload-time = "2025-06-21T12:20:31.002Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/ec/3b68220c277e463095342d254c61be8144c31208db18d3fd8ef02712bcd6/numpy-2.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:36890eb9e9d2081137bd78d29050ba63b8dab95dff7912eadf1185e80074b2a0", size = 15562538, upload-time = "2025-06-21T12:20:54.322Z" },
-    { url = "https://files.pythonhosted.org/packages/77/2b/4014f2bcc4404484021c74d4c5ee8eb3de7e3f7ac75f06672f8dcf85140a/numpy-2.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a780033466159c2270531e2b8ac063704592a0bc62ec4a1b991c7c40705eb0e8", size = 18360327, upload-time = "2025-06-21T12:21:21.053Z" },
-    { url = "https://files.pythonhosted.org/packages/40/8d/2ddd6c9b30fcf920837b8672f6c65590c7d92e43084c25fc65edc22e93ca/numpy-2.3.1-cp313-cp313-win32.whl", hash = "sha256:39bff12c076812595c3a306f22bfe49919c5513aa1e0e70fac756a0be7c2a2b8", size = 6312330, upload-time = "2025-06-21T12:25:07.447Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/c8/beaba449925988d415efccb45bf977ff8327a02f655090627318f6398c7b/numpy-2.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d5ee6eec45f08ce507a6570e06f2f879b374a552087a4179ea7838edbcbfa42", size = 12731565, upload-time = "2025-06-21T12:25:26.444Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/c3/5c0c575d7ec78c1126998071f58facfc124006635da75b090805e642c62e/numpy-2.3.1-cp313-cp313-win_arm64.whl", hash = "sha256:0c4d9e0a8368db90f93bd192bfa771ace63137c3488d198ee21dfb8e7771916e", size = 10190262, upload-time = "2025-06-21T12:25:42.196Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/19/a029cd335cf72f79d2644dcfc22d90f09caa86265cbbde3b5702ccef6890/numpy-2.3.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:b0b5397374f32ec0649dd98c652a1798192042e715df918c20672c62fb52d4b8", size = 20987593, upload-time = "2025-06-21T12:21:51.664Z" },
-    { url = "https://files.pythonhosted.org/packages/25/91/8ea8894406209107d9ce19b66314194675d31761fe2cb3c84fe2eeae2f37/numpy-2.3.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:c5bdf2015ccfcee8253fb8be695516ac4457c743473a43290fd36eba6a1777eb", size = 14300523, upload-time = "2025-06-21T12:22:13.583Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/7f/06187b0066eefc9e7ce77d5f2ddb4e314a55220ad62dd0bfc9f2c44bac14/numpy-2.3.1-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:d70f20df7f08b90a2062c1f07737dd340adccf2068d0f1b9b3d56e2038979fee", size = 5227993, upload-time = "2025-06-21T12:22:22.53Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/ec/a926c293c605fa75e9cfb09f1e4840098ed46d2edaa6e2152ee35dc01ed3/numpy-2.3.1-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:2fb86b7e58f9ac50e1e9dd1290154107e47d1eef23a0ae9145ded06ea606f992", size = 6736652, upload-time = "2025-06-21T12:22:33.629Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/62/d68e52fb6fde5586650d4c0ce0b05ff3a48ad4df4ffd1b8866479d1d671d/numpy-2.3.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:23ab05b2d241f76cb883ce8b9a93a680752fbfcbd51c50eff0b88b979e471d8c", size = 14331561, upload-time = "2025-06-21T12:22:55.056Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/ec/b74d3f2430960044bdad6900d9f5edc2dc0fb8bf5a0be0f65287bf2cbe27/numpy-2.3.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:ce2ce9e5de4703a673e705183f64fd5da5bf36e7beddcb63a25ee2286e71ca48", size = 16693349, upload-time = "2025-06-21T12:23:20.53Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/15/def96774b9d7eb198ddadfcbd20281b20ebb510580419197e225f5c55c3e/numpy-2.3.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c4913079974eeb5c16ccfd2b1f09354b8fed7e0d6f2cab933104a09a6419b1ee", size = 15642053, upload-time = "2025-06-21T12:23:43.697Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/57/c3203974762a759540c6ae71d0ea2341c1fa41d84e4971a8e76d7141678a/numpy-2.3.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:010ce9b4f00d5c036053ca684c77441f2f2c934fd23bee058b4d6f196efd8280", size = 18434184, upload-time = "2025-06-21T12:24:10.708Z" },
-    { url = "https://files.pythonhosted.org/packages/22/8a/ccdf201457ed8ac6245187850aff4ca56a79edbea4829f4e9f14d46fa9a5/numpy-2.3.1-cp313-cp313t-win32.whl", hash = "sha256:6269b9edfe32912584ec496d91b00b6d34282ca1d07eb10e82dfc780907d6c2e", size = 6440678, upload-time = "2025-06-21T12:24:21.596Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/7e/7f431d8bd8eb7e03d79294aed238b1b0b174b3148570d03a8a8a8f6a0da9/numpy-2.3.1-cp313-cp313t-win_amd64.whl", hash = "sha256:2a809637460e88a113e186e87f228d74ae2852a2e0c44de275263376f17b5bdc", size = 12870697, upload-time = "2025-06-21T12:24:40.644Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/ca/af82bf0fad4c3e573c6930ed743b5308492ff19917c7caaf2f9b6f9e2e98/numpy-2.3.1-cp313-cp313t-win_arm64.whl", hash = "sha256:eccb9a159db9aed60800187bc47a6d3451553f0e1b08b068d8b277ddfbb9b244", size = 10260376, upload-time = "2025-06-21T12:24:56.884Z" },
+    { url = "https://files.pythonhosted.org/packages/95/12/8f2020a8e8b8383ac0177dc9570aad031a3beb12e38847f7129bacd96228/numpy-1.26.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b3ce300f3644fb06443ee2222c2201dd3a89ea6040541412b8fa189341847218", size = 20335901, upload-time = "2024-02-05T23:55:32.801Z" },
+    { url = "https://files.pythonhosted.org/packages/75/5b/ca6c8bd14007e5ca171c7c03102d17b4f4e0ceb53957e8c44343a9546dcc/numpy-1.26.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:03a8c78d01d9781b28a6989f6fa1bb2c4f2d51201cf99d3dd875df6fbd96b23b", size = 13685868, upload-time = "2024-02-05T23:55:56.28Z" },
+    { url = "https://files.pythonhosted.org/packages/79/f8/97f10e6755e2a7d027ca783f63044d5b1bc1ae7acb12afe6a9b4286eac17/numpy-1.26.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9fad7dcb1aac3c7f0584a5a8133e3a43eeb2fe127f47e3632d43d677c66c102b", size = 13925109, upload-time = "2024-02-05T23:56:20.368Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/50/de23fde84e45f5c4fda2488c759b69990fd4512387a8632860f3ac9cd225/numpy-1.26.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:675d61ffbfa78604709862923189bad94014bef562cc35cf61d3a07bba02a7ed", size = 17950613, upload-time = "2024-02-05T23:56:56.054Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/0c/9c603826b6465e82591e05ca230dfc13376da512b25ccd0894709b054ed0/numpy-1.26.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ab47dbe5cc8210f55aa58e4805fe224dac469cde56b9f731a4c098b91917159a", size = 13572172, upload-time = "2024-02-05T23:57:21.56Z" },
+    { url = "https://files.pythonhosted.org/packages/76/8c/2ba3902e1a0fc1c74962ea9bb33a534bb05984ad7ff9515bf8d07527cadd/numpy-1.26.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1dda2e7b4ec9dd512f84935c5f126c8bd8b9f2fc001e9f54af255e8c5f16b0e0", size = 17786643, upload-time = "2024-02-05T23:57:56.585Z" },
+    { url = "https://files.pythonhosted.org/packages/28/4a/46d9e65106879492374999e76eb85f87b15328e06bd1550668f79f7b18c6/numpy-1.26.4-cp312-cp312-win32.whl", hash = "sha256:50193e430acfc1346175fcbdaa28ffec49947a06918b7b92130744e81e640110", size = 5677803, upload-time = "2024-02-05T23:58:08.963Z" },
+    { url = "https://files.pythonhosted.org/packages/16/2e/86f24451c2d530c88daf997cb8d6ac622c1d40d19f5a031ed68a4b73a374/numpy-1.26.4-cp312-cp312-win_amd64.whl", hash = "sha256:08beddf13648eb95f8d867350f6a018a4be2e5ad54c8d8caed89ebca558b2818", size = 15517754, upload-time = "2024-02-05T23:58:36.364Z" },
 ]
 
 [[package]]
@@ -1091,7 +1228,6 @@ dependencies = [
     { name = "instructor" },
     { name = "jsonschema" },
     { name = "litellm" },
-    { name = "numpy" },
     { name = "ollama" },
     { name = "polars" },
     { name = "pyarrow" },
@@ -1100,6 +1236,11 @@ dependencies = [
     { name = "pygments" },
     { name = "python-dotenv" },
     { name = "requests" },
+]
+
+[package.optional-dependencies]
+text2term = [
+    { name = "text2term" },
 ]
 
 [package.dev-dependencies]
@@ -1117,7 +1258,6 @@ requires-dist = [
     { name = "instructor", specifier = ">=1.14.5" },
     { name = "jsonschema", specifier = ">=4.23.0,<5" },
     { name = "litellm", specifier = ">=1.82.2" },
-    { name = "numpy", specifier = ">=2.3.1,<3" },
     { name = "ollama", specifier = ">=0.5.1,<0.6" },
     { name = "polars", specifier = ">=1.38.1" },
     { name = "pyarrow", specifier = ">=20.0.0,<21" },
@@ -1125,7 +1265,9 @@ requires-dist = [
     { name = "pygments", specifier = ">=2.19.1,<3" },
     { name = "python-dotenv", specifier = ">=1.0.1,<2" },
     { name = "requests", specifier = ">=2.32.5" },
+    { name = "text2term", marker = "extra == 'text2term'", specifier = ">=4.5.0" },
 ]
+provides-extras = ["text2term"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1136,12 +1278,52 @@ dev = [
 ]
 
 [[package]]
+name = "owlready2"
+version = "0.50"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/67/6fb3a628889d97f8a3d3c64d4597f0637db61a1856c835fe7c65d8e89658/owlready2-0.50.tar.gz", hash = "sha256:7be74c53a35497df138c8223dddcf65510def9b38494ae1fac4aa2a61c4677eb", size = 27328931, upload-time = "2026-02-05T10:42:01.733Z" }
+
+[[package]]
 name = "packaging"
 version = "24.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d0/63/68dbb6eb2de9cb10ee4c9c14a0148804425e13c4fb20d61cce69f53106da/packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f", size = 163950, upload-time = "2024-11-08T09:47:47.202Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759", size = 65451, upload-time = "2024-11-08T09:47:44.722Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "2.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/d6/9f8431bacc2e19dca897724cd097b1bb224a6ad5433784a44b587c7c13af/pandas-2.2.3.tar.gz", hash = "sha256:4f18ba62b61d7e192368b84517265a99b4d7ee8912f8708660fb4a366cc82667", size = 4399213, upload-time = "2024-09-20T13:10:04.827Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/a3/fb2734118db0af37ea7433f57f722c0a56687e14b14690edff0cdb4b7e58/pandas-2.2.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:b1d432e8d08679a40e2a6d8b2f9770a5c21793a6f9f47fdd52c5ce1948a5a8a9", size = 12529893, upload-time = "2024-09-20T13:09:09.655Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/0c/ad295fd74bfac85358fd579e271cded3ac969de81f62dd0142c426b9da91/pandas-2.2.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a5a1595fe639f5988ba6a8e5bc9649af3baf26df3998a0abe56c02609392e0a4", size = 11363475, upload-time = "2024-09-20T13:09:14.718Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/2a/4bba3f03f7d07207481fed47f5b35f556c7441acddc368ec43d6643c5777/pandas-2.2.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5de54125a92bb4d1c051c0659e6fcb75256bf799a732a87184e5ea503965bce3", size = 15188645, upload-time = "2024-09-20T19:02:03.88Z" },
+    { url = "https://files.pythonhosted.org/packages/38/f8/d8fddee9ed0d0c0f4a2132c1dfcf0e3e53265055da8df952a53e7eaf178c/pandas-2.2.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fffb8ae78d8af97f849404f21411c95062db1496aeb3e56f146f0355c9989319", size = 12739445, upload-time = "2024-09-20T13:09:17.621Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e8/45a05d9c39d2cea61ab175dbe6a2de1d05b679e8de2011da4ee190d7e748/pandas-2.2.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6dfcb5ee8d4d50c06a51c2fffa6cff6272098ad6540aed1a76d15fb9318194d8", size = 16359235, upload-time = "2024-09-20T19:02:07.094Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/99/617d07a6a5e429ff90c90da64d428516605a1ec7d7bea494235e1c3882de/pandas-2.2.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:062309c1b9ea12a50e8ce661145c6aab431b1e99530d3cd60640e255778bd43a", size = 14056756, upload-time = "2024-09-20T13:09:20.474Z" },
+    { url = "https://files.pythonhosted.org/packages/29/d4/1244ab8edf173a10fd601f7e13b9566c1b525c4f365d6bee918e68381889/pandas-2.2.3-cp312-cp312-win_amd64.whl", hash = "sha256:59ef3764d0fe818125a5097d2ae867ca3fa64df032331b7e0917cf5d7bf66b13", size = 11504248, upload-time = "2024-09-20T13:09:23.137Z" },
+    { url = "https://files.pythonhosted.org/packages/64/22/3b8f4e0ed70644e85cfdcd57454686b9057c6c38d2f74fe4b8bc2527214a/pandas-2.2.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f00d1345d84d8c86a63e476bb4955e46458b304b9575dcf71102b5c705320015", size = 12477643, upload-time = "2024-09-20T13:09:25.522Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/93/b3f5d1838500e22c8d793625da672f3eec046b1a99257666c94446969282/pandas-2.2.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3508d914817e153ad359d7e069d752cdd736a247c322d932eb89e6bc84217f28", size = 11281573, upload-time = "2024-09-20T13:09:28.012Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/94/6c79b07f0e5aab1dcfa35a75f4817f5c4f677931d4234afcd75f0e6a66ca/pandas-2.2.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22a9d949bfc9a502d320aa04e5d02feab689d61da4e7764b62c30b991c42c5f0", size = 15196085, upload-time = "2024-09-20T19:02:10.451Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/31/aa8da88ca0eadbabd0a639788a6da13bb2ff6edbbb9f29aa786450a30a91/pandas-2.2.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3a255b2c19987fbbe62a9dfd6cff7ff2aa9ccab3fc75218fd4b7530f01efa24", size = 12711809, upload-time = "2024-09-20T13:09:30.814Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7c/c6dbdb0cb2a4344cacfb8de1c5808ca885b2e4dcfde8008266608f9372af/pandas-2.2.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:800250ecdadb6d9c78eae4990da62743b857b470883fa27f652db8bdde7f6659", size = 16356316, upload-time = "2024-09-20T19:02:13.825Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b7/8b757e7d92023b832869fa8881a992696a0bfe2e26f72c9ae9f255988d42/pandas-2.2.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6374c452ff3ec675a8f46fd9ab25c4ad0ba590b71cf0656f8b6daa5202bca3fb", size = 14022055, upload-time = "2024-09-20T13:09:33.462Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/bc/4b18e2b8c002572c5a441a64826252ce5da2aa738855747247a971988043/pandas-2.2.3-cp313-cp313-win_amd64.whl", hash = "sha256:61c5ad4043f791b61dd4752191d9f07f0ae412515d59ba8f005832a532f8736d", size = 11481175, upload-time = "2024-09-20T13:09:35.871Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a3/a5d88146815e972d40d19247b2c162e88213ef51c7c25993942c39dbf41d/pandas-2.2.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:3b71f27954685ee685317063bf13c7709a7ba74fc996b84fc6821c59b0f06468", size = 12615650, upload-time = "2024-09-20T13:09:38.685Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8c/f0fd18f6140ddafc0c24122c8a964e48294acc579d47def376fef12bcb4a/pandas-2.2.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:38cf8125c40dae9d5acc10fa66af8ea6fdf760b2714ee482ca691fc66e6fcb18", size = 11290177, upload-time = "2024-09-20T13:09:41.141Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/f9/e995754eab9c0f14c6777401f7eece0943840b7a9fc932221c19d1abee9f/pandas-2.2.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ba96630bc17c875161df3818780af30e43be9b166ce51c9a18c1feae342906c2", size = 14651526, upload-time = "2024-09-20T19:02:16.905Z" },
+    { url = "https://files.pythonhosted.org/packages/25/b0/98d6ae2e1abac4f35230aa756005e8654649d305df9a28b16b9ae4353bff/pandas-2.2.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db71525a1538b30142094edb9adc10be3f3e176748cd7acc2240c2f2e5aa3a4", size = 11871013, upload-time = "2024-09-20T13:09:44.39Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/57/0f72a10f9db6a4628744c8e8f0df4e6e21de01212c7c981d31e50ffc8328/pandas-2.2.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:15c0e1e02e93116177d29ff83e8b1619c93ddc9c49083f237d4312337a61165d", size = 15711620, upload-time = "2024-09-20T19:02:20.639Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/5f/b38085618b950b79d2d9164a711c52b10aefc0ae6833b96f626b7021b2ed/pandas-2.2.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:ad5b65698ab28ed8d7f18790a0dc58005c7629f227be9ecc1072aa74c0c1d43a", size = 13098436, upload-time = "2024-09-20T13:09:48.112Z" },
 ]
 
 [[package]]
@@ -1297,6 +1479,34 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/ef/3c6ecf8b317aa982f309835e8f96987466123c6e596646d4e6a1dfcd080f/propcache-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:990f6b3e2a27d683cb7602ed6c86f15ee6b43b1194736f9baaeb93d0016633b1", size = 46259, upload-time = "2025-10-08T19:48:34.226Z" },
     { url = "https://files.pythonhosted.org/packages/c4/2d/346e946d4951f37eca1e4f55be0f0174c52cd70720f84029b02f296f4a38/propcache-0.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ecef2343af4cc68e05131e45024ba34f6095821988a9d0a02aa7c73fcc448aa9", size = 40428, upload-time = "2025-10-08T19:48:35.441Z" },
     { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305, upload-time = "2025-10-08T19:49:00.792Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
 ]
 
 [[package]]
@@ -1495,6 +1705,22 @@ wheels = [
 ]
 
 [[package]]
+name = "pystow"
+version = "0.7.28"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "requests" },
+    { name = "tqdm" },
+    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/0d/b107972e085ec13c71d0beb3fa39103e2fe48f5f310acf3dffd9a0ba851b/pystow-0.7.28.tar.gz", hash = "sha256:7c043bda2e4d6d8de8ae8e3944d2caeef5dd370e81df31e2e74557eaa574946a", size = 50905, upload-time = "2026-02-19T13:23:31.523Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/3a/8dfc7e10341d6331dc2ccc09afb8d25501565112798adbd90cf35528c9ab/pystow-0.7.28-py3-none-any.whl", hash = "sha256:aa73dec0f6dea8bfc844f3abd3d985d6d3594291ebd234d9ec05b16884b13336", size = 57950, upload-time = "2026-02-19T13:23:33.182Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "8.3.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1519,6 +1745,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c6/90/a955c3ab35ccd41ad4de556596fa86685bf4fc5ffcc62d22d856cfd4e29a/pytest-mock-3.14.0.tar.gz", hash = "sha256:2719255a1efeceadbc056d6bf3df3d1c5015530fb40cf347c0f9afac88410bd0", size = 32814, upload-time = "2024-03-21T22:14:04.964Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f2/3b/b26f90f74e2986a82df6e7ac7e319b8ea7ccece1caec9f8ab6104dc70603/pytest_mock-3.14.0-py3-none-any.whl", hash = "sha256:0b72c38033392a5f4621342fe11e9219ac11ec9d375f8e2a0c164539e0d70f6f", size = 9863, upload-time = "2024-03-21T22:14:02.694Z" },
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
 ]
 
 [[package]]
@@ -1560,6 +1798,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pytz"
+version = "2026.1.post1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/db/b8721d71d945e6a8ac63c0fc900b2067181dbb50805958d4d4661cf7d277/pytz-2026.1.post1.tar.gz", hash = "sha256:3378dde6a0c3d26719182142c56e60c7f9af7e968076f31aae569d72a0358ee1", size = 321088, upload-time = "2026-03-03T07:47:50.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/99/781fe0c827be2742bcc775efefccb3b048a3a9c6ce9aec0cbf4a101677e5/pytz-2026.1.post1-py2.py3-none-any.whl", hash = "sha256:f2fd16142fda348286a75e1a524be810bb05d444e5a081f37f7affc635035f7a", size = 510489, upload-time = "2026-03-03T07:47:49.167Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1583,6 +1830,44 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597, upload-time = "2024-08-06T20:32:56.985Z" },
     { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527, upload-time = "2024-08-06T20:33:03.001Z" },
     { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446, upload-time = "2024-08-06T20:33:04.33Z" },
+]
+
+[[package]]
+name = "rapidfuzz"
+version = "3.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/be/8dff25a6157dfbde9867720b1282157fe7b809e085130bb89d7655c62186/rapidfuzz-3.12.2.tar.gz", hash = "sha256:b0ba1ccc22fff782e7152a3d3d0caca44ec4e32dc48ba01c560b8593965b5aa3", size = 57907839, upload-time = "2025-03-02T18:32:28.366Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/d2/e071753227c9e9f7f3550b983f30565f6e994581529815fa5a8879e7cd10/rapidfuzz-3.12.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:1d982a651253ffe8434d9934ff0c1089111d60502228464721a2a4587435e159", size = 1944403, upload-time = "2025-03-02T18:29:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/d1/4a10d21cc97aa36f4019af24382b5b4dc5ea6444499883c1c1286c6089ba/rapidfuzz-3.12.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:02e6466caa0222d5233b1f05640873671cd99549a5c5ba4c29151634a1e56080", size = 1430287, upload-time = "2025-03-02T18:29:56.464Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/2d/76d39ab0beeb884d432096fe288c41850e37608e0145264081d0cb809f3c/rapidfuzz-3.12.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e956b3f053e474abae69ac693a52742109d860ac2375fe88e9387d3277f4c96c", size = 1403693, upload-time = "2025-03-02T18:29:58.704Z" },
+    { url = "https://files.pythonhosted.org/packages/85/1a/719b0f6498c003627e4b83b841bdcd48b11de8a9908a9051c4d2a0bc2245/rapidfuzz-3.12.2-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2dee7d740a2d5418d4f964f39ab8d89923e6b945850db833e798a1969b19542a", size = 5555878, upload-time = "2025-03-02T18:30:01.842Z" },
+    { url = "https://files.pythonhosted.org/packages/af/48/14d952a73254b4b0e517141acd27979bd23948adaf197f6ca2dc722fde6a/rapidfuzz-3.12.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a057cdb0401e42c84b6516c9b1635f7aedd5e430c6e388bd5f6bcd1d6a0686bb", size = 1655301, upload-time = "2025-03-02T18:30:03.647Z" },
+    { url = "https://files.pythonhosted.org/packages/db/3f/b093e154e9752325d7459aa6dca43b7acbcaffa05133507e2403676e3e75/rapidfuzz-3.12.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dccf8d4fb5b86d39c581a59463c596b1d09df976da26ff04ae219604223d502f", size = 1678069, upload-time = "2025-03-02T18:30:06.737Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/7e/88853ecae5b5456eb1a1d8a01cbd534e25b671735d5d974609cbae082542/rapidfuzz-3.12.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21d5b3793c6f5aecca595cd24164bf9d3c559e315ec684f912146fc4e769e367", size = 3137119, upload-time = "2025-03-02T18:30:08.544Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/d2/b1f809b815aaf682ddac9c57929149f740b90feeb4f8da2f535c196de821/rapidfuzz-3.12.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:46a616c0e13cff2de1761b011e0b14bb73b110182f009223f1453d505c9a975c", size = 2491639, upload-time = "2025-03-02T18:30:10.425Z" },
+    { url = "https://files.pythonhosted.org/packages/61/e4/a908d7b8db6e52ba2f80f6f0d0709ef9fdedb767db4307084331742b67f0/rapidfuzz-3.12.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:19fa5bc4301a1ee55400d4a38a8ecf9522b0391fc31e6da5f4d68513fe5c0026", size = 7821561, upload-time = "2025-03-02T18:30:13.21Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/83/0250c49deefff15c46f5e590d8ee6abbd0f056e20b85994db55c16ac6ead/rapidfuzz-3.12.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:544a47190a0d25971658a9365dba7095397b4ce3e897f7dd0a77ca2cf6fa984e", size = 2874048, upload-time = "2025-03-02T18:30:15.225Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/3f/8d433d964c6e476476ee53eae5fa77b9f16b38d312eb1571e9099a6a3b12/rapidfuzz-3.12.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:f21af27c5e001f0ba1b88c36a0936437dfe034c452548d998891c21125eb640f", size = 3522801, upload-time = "2025-03-02T18:30:17.214Z" },
+    { url = "https://files.pythonhosted.org/packages/82/85/4931bfa41ef837b1544838e46e0556640d18114b3da9cf05e10defff00ae/rapidfuzz-3.12.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b63170d9db00629b5b3f2862114d8d6ee19127eaba0eee43762d62a25817dbe0", size = 4567304, upload-time = "2025-03-02T18:30:20.035Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/fe/fdae322869885115dd19a38c1da71b73a8832aa77757c93f460743d4f54c/rapidfuzz-3.12.2-cp312-cp312-win32.whl", hash = "sha256:6c7152d77b2eb6bfac7baa11f2a9c45fd5a2d848dbb310acd0953b3b789d95c9", size = 1845332, upload-time = "2025-03-02T18:30:22.705Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/a4/2ccebda5fb8a266d163d57a42c2a6ef6f91815df5d89cf38c12e8aa6ed0b/rapidfuzz-3.12.2-cp312-cp312-win_amd64.whl", hash = "sha256:1a314d170ee272ac87579f25a6cf8d16a031e1f7a7b07663434b41a1473bc501", size = 1617926, upload-time = "2025-03-02T18:30:24.622Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/bc/aa8a4dc4ebff966dd039cce017c614cfd202049b4d1a2daafee7d018521b/rapidfuzz-3.12.2-cp312-cp312-win_arm64.whl", hash = "sha256:d41e8231326e94fd07c4d8f424f6bed08fead6f5e6688d1e6e787f1443ae7631", size = 864737, upload-time = "2025-03-02T18:30:26.508Z" },
+    { url = "https://files.pythonhosted.org/packages/96/59/2ea3b5bb82798eae73d6ee892264ebfe42727626c1f0e96c77120f0d5cf6/rapidfuzz-3.12.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:941f31038dba5d3dedcfcceba81d61570ad457c873a24ceb13f4f44fcb574260", size = 1936870, upload-time = "2025-03-02T18:30:28.423Z" },
+    { url = "https://files.pythonhosted.org/packages/54/85/4e486bf9ea05e771ad231731305ed701db1339157f630b76b246ce29cf71/rapidfuzz-3.12.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fe2dfc454ee51ba168a67b1e92b72aad251e45a074972cef13340bbad2fd9438", size = 1424231, upload-time = "2025-03-02T18:30:30.144Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/60/aeea3eed402c40a8cf055d554678769fbee0dd95c22f04546070a22bb90e/rapidfuzz-3.12.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:78fafaf7f5a48ee35ccd7928339080a0136e27cf97396de45259eca1d331b714", size = 1398055, upload-time = "2025-03-02T18:30:31.999Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6b/757106f4c21fe3f20ce13ba3df560da60e52fe0dc390fd22bf613761669c/rapidfuzz-3.12.2-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e0c7989ff32c077bb8fd53253fd6ca569d1bfebc80b17557e60750e6909ba4fe", size = 5526188, upload-time = "2025-03-02T18:30:34.002Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/a2/7c680cdc5532746dba67ecf302eed975252657094e50ae334fa9268352e8/rapidfuzz-3.12.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:96fa00bc105caa34b6cd93dca14a29243a3a7f0c336e4dcd36348d38511e15ac", size = 1648483, upload-time = "2025-03-02T18:30:36.197Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/b0/ce942a1448b1a75d64af230dd746dede502224dd29ca9001665bbfd4bee6/rapidfuzz-3.12.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bccfb30c668620c5bc3490f2dc7d7da1cca0ead5a9da8b755e2e02e2ef0dff14", size = 1676076, upload-time = "2025-03-02T18:30:38.335Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/71/81f77b08333200be6984b6cdf2bdfd7cfca4943f16b478a2f7838cba8d66/rapidfuzz-3.12.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2f9b0adc3d894beb51f5022f64717b6114a6fabaca83d77e93ac7675911c8cc5", size = 3114169, upload-time = "2025-03-02T18:30:40.485Z" },
+    { url = "https://files.pythonhosted.org/packages/01/16/f3f34b207fdc8c61a33f9d2d61fc96b62c7dadca88bda1df1be4b94afb0b/rapidfuzz-3.12.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:32691aa59577f42864d5535cb6225d0f47e2c7bff59cf4556e5171e96af68cc1", size = 2485317, upload-time = "2025-03-02T18:30:42.392Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a6/b954f0766f644eb8dd8df44703e024ab4f5f15a8f8f5ea969963dd036f50/rapidfuzz-3.12.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:758b10380ad34c1f51753a070d7bb278001b5e6fcf544121c6df93170952d705", size = 7844495, upload-time = "2025-03-02T18:30:44.732Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/8f/1dc604d05e07150a02b56a8ffc47df75ce316c65467259622c9edf098451/rapidfuzz-3.12.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:50a9c54c0147b468363119132d514c5024fbad1ed8af12bd8bd411b0119f9208", size = 2873242, upload-time = "2025-03-02T18:30:47.208Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a9/9c649ace4b7f885e0a5fdcd1f33b057ebd83ecc2837693e6659bd944a2bb/rapidfuzz-3.12.2-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:e3ceb87c11d2d0fbe8559bb795b0c0604b84cfc8bb7b8720b5c16e9e31e00f41", size = 3519124, upload-time = "2025-03-02T18:30:49.175Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/81/ce0b774e540a2e22ec802e383131d7ead18347197304d584c4ccf7b8861a/rapidfuzz-3.12.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f7c9a003002434889255ff5676ca0f8934a478065ab5e702f75dc42639505bba", size = 4557831, upload-time = "2025-03-02T18:30:51.24Z" },
+    { url = "https://files.pythonhosted.org/packages/13/28/7bf0ee8d35efa7ab14e83d1795cdfd54833aa0428b6f87e987893136c372/rapidfuzz-3.12.2-cp313-cp313-win32.whl", hash = "sha256:cf165a76870cd875567941cf861dfd361a0a6e6a56b936c5d30042ddc9def090", size = 1842802, upload-time = "2025-03-02T18:30:53.185Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/7e/792d609484776c8a40e1695ebd28b62196be9f8347b785b9104604dc7268/rapidfuzz-3.12.2-cp313-cp313-win_amd64.whl", hash = "sha256:55bcc003541f5f16ec0a73bf6de758161973f9e8d75161954380738dd147f9f2", size = 1615808, upload-time = "2025-03-02T18:30:55.299Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/43/ca3d1018b392f49131843648e10b08ace23afe8dad3bee5f136e4346b7cd/rapidfuzz-3.12.2-cp313-cp313-win_arm64.whl", hash = "sha256:69f6ecdf1452139f2b947d0c169a605de578efdb72cbb2373cb0a94edca1fd34", size = 863535, upload-time = "2025-03-02T18:30:57.992Z" },
 ]
 
 [[package]]
@@ -1716,6 +2001,27 @@ wheels = [
 ]
 
 [[package]]
+name = "roman-numerals"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/f9/41dc953bbeb056c17d5f7a519f50fdf010bd0553be2d630bc69d1e022703/roman_numerals-4.1.0.tar.gz", hash = "sha256:1af8b147eb1405d5839e78aeb93131690495fe9da5c91856cb33ad55a7f1e5b2", size = 9077, upload-time = "2025-12-17T18:25:34.381Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/54/6f679c435d28e0a568d8e8a7c0a93a09010818634c3c3907fc98d8983770/roman_numerals-4.1.0-py3-none-any.whl", hash = "sha256:647ba99caddc2cc1e55a51e4360689115551bf4476d90e8162cf8c345fe233c7", size = 7676, upload-time = "2025-12-17T18:25:33.098Z" },
+]
+
+[[package]]
+name = "roman-numerals-py"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "roman-numerals" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/b5/de96fca640f4f656eb79bbee0e79aeec52e3e0e359f8a3e6a0d366378b64/roman_numerals_py-4.1.0.tar.gz", hash = "sha256:f5d7b2b4ca52dd855ef7ab8eb3590f428c0b1ea480736ce32b01fef2a5f8daf9", size = 4274, upload-time = "2025-12-17T18:25:41.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/2c/daca29684cbe9fd4bc711f8246da3c10adca1ccc4d24436b17572eb2590e/roman_numerals_py-4.1.0-py3-none-any.whl", hash = "sha256:553114c1167141c1283a51743759723ecd05604a1b6b507225e91dc1a6df0780", size = 4547, upload-time = "2025-12-17T18:25:40.136Z" },
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.22.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1763,12 +2069,96 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-learn"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/a5/4ae3b3a0755f7b35a280ac90b28817d1f380318973cff14075ab41ef50d9/scikit_learn-1.6.1.tar.gz", hash = "sha256:b4fc2525eca2c69a59260f583c56a7557c6ccdf8deafdba6e060f94c1c59738e", size = 7068312, upload-time = "2025-01-10T08:07:55.348Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/18/c797c9b8c10380d05616db3bfb48e2a3358c767affd0857d56c2eb501caa/scikit_learn-1.6.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:926f207c804104677af4857b2c609940b743d04c4c35ce0ddc8ff4f053cddc1b", size = 12104516, upload-time = "2025-01-10T08:06:40.009Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b7/2e35f8e289ab70108f8cbb2e7a2208f0575dc704749721286519dcf35f6f/scikit_learn-1.6.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:2c2cae262064e6a9b77eee1c8e768fc46aa0b8338c6a8297b9b6759720ec0ff2", size = 11167837, upload-time = "2025-01-10T08:06:43.305Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/f6/ff7beaeb644bcad72bcfd5a03ff36d32ee4e53a8b29a639f11bcb65d06cd/scikit_learn-1.6.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1061b7c028a8663fb9a1a1baf9317b64a257fcb036dae5c8752b2abef31d136f", size = 12253728, upload-time = "2025-01-10T08:06:47.618Z" },
+    { url = "https://files.pythonhosted.org/packages/29/7a/8bce8968883e9465de20be15542f4c7e221952441727c4dad24d534c6d99/scikit_learn-1.6.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2e69fab4ebfc9c9b580a7a80111b43d214ab06250f8a7ef590a4edf72464dd86", size = 13147700, upload-time = "2025-01-10T08:06:50.888Z" },
+    { url = "https://files.pythonhosted.org/packages/62/27/585859e72e117fe861c2079bcba35591a84f801e21bc1ab85bce6ce60305/scikit_learn-1.6.1-cp312-cp312-win_amd64.whl", hash = "sha256:70b1d7e85b1c96383f872a519b3375f92f14731e279a7b4c6cfd650cf5dffc52", size = 11110613, upload-time = "2025-01-10T08:06:54.115Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/59/8eb1872ca87009bdcdb7f3cdc679ad557b992c12f4b61f9250659e592c63/scikit_learn-1.6.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:2ffa1e9e25b3d93990e74a4be2c2fc61ee5af85811562f1288d5d055880c4322", size = 12010001, upload-time = "2025-01-10T08:06:58.613Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/05/f2fc4effc5b32e525408524c982c468c29d22f828834f0625c5ef3d601be/scikit_learn-1.6.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:dc5cf3d68c5a20ad6d571584c0750ec641cc46aeef1c1507be51300e6003a7e1", size = 11096360, upload-time = "2025-01-10T08:07:01.556Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/e4/4195d52cf4f113573fb8ebc44ed5a81bd511a92c0228889125fac2f4c3d1/scikit_learn-1.6.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c06beb2e839ecc641366000ca84f3cf6fa9faa1777e29cf0c04be6e4d096a348", size = 12209004, upload-time = "2025-01-10T08:07:06.931Z" },
+    { url = "https://files.pythonhosted.org/packages/94/be/47e16cdd1e7fcf97d95b3cb08bde1abb13e627861af427a3651fcb80b517/scikit_learn-1.6.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e8ca8cb270fee8f1f76fa9bfd5c3507d60c6438bbee5687f81042e2bb98e5a97", size = 13171776, upload-time = "2025-01-10T08:07:11.715Z" },
+    { url = "https://files.pythonhosted.org/packages/34/b0/ca92b90859070a1487827dbc672f998da95ce83edce1270fc23f96f1f61a/scikit_learn-1.6.1-cp313-cp313-win_amd64.whl", hash = "sha256:7a1c43c8ec9fde528d664d947dc4c0789be4077a3647f232869f41d9bf50e0fb", size = 11071865, upload-time = "2025-01-10T08:07:16.088Z" },
+    { url = "https://files.pythonhosted.org/packages/12/ae/993b0fb24a356e71e9a894e42b8a9eec528d4c70217353a1cd7a48bc25d4/scikit_learn-1.6.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:a17c1dea1d56dcda2fac315712f3651a1fea86565b64b48fa1bc090249cbf236", size = 11955804, upload-time = "2025-01-10T08:07:20.385Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/54/32fa2ee591af44507eac86406fa6bba968d1eb22831494470d0a2e4a1eb1/scikit_learn-1.6.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:6a7aa5f9908f0f28f4edaa6963c0a6183f1911e63a69aa03782f0d924c830a35", size = 11100530, upload-time = "2025-01-10T08:07:23.675Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/58/55856da1adec655bdce77b502e94a267bf40a8c0b89f8622837f89503b5a/scikit_learn-1.6.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0650e730afb87402baa88afbf31c07b84c98272622aaba002559b614600ca691", size = 12433852, upload-time = "2025-01-10T08:07:26.817Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/4f/c83853af13901a574f8f13b645467285a48940f185b690936bb700a50863/scikit_learn-1.6.1-cp313-cp313t-win_amd64.whl", hash = "sha256:3f59fe08dc03ea158605170eb52b22a105f238a5d512c4470ddeca71feae8e5f", size = 11337256, upload-time = "2025-01-10T08:07:31.084Z" },
+]
+
+[[package]]
+name = "scipy"
+version = "1.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/85/cdbf2c3c460fe5aae812917866392068a88d02f07de0fe31ce738734c477/scipy-1.12.0.tar.gz", hash = "sha256:4bf5abab8a36d20193c698b0f1fc282c1d083c94723902c447e5d2f1780936a3", size = 56811768, upload-time = "2024-01-20T21:13:43.442Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/4a/b2b2cae0c5dfd46361245a67102886ed7188805bdf7044e36fe838bbcf26/scipy-1.12.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:e7e76cc48638228212c747ada851ef355c2bb5e7f939e10952bc504c11f4e372", size = 38911995, upload-time = "2024-01-20T21:11:54.759Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ba/744bbdd65eb3fce1412dd4633fc425ad39e6b4068b5b158aee1cd3afeb54/scipy-1.12.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:f7ce148dffcd64ade37b2df9315541f9adad6efcaa86866ee7dd5db0c8f041c3", size = 31433326, upload-time = "2024-01-20T21:12:00.295Z" },
+    { url = "https://files.pythonhosted.org/packages/db/fd/81feac476e1ae495b51b8c3636aee1f50a1c5ca2a3557f5b0043d4e2fb02/scipy-1.12.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9c39f92041f490422924dfdb782527a4abddf4707616e07b021de33467f917bc", size = 34165749, upload-time = "2024-01-20T21:12:06.38Z" },
+    { url = "https://files.pythonhosted.org/packages/11/7d/850bfe9462fff393130519eb54f97d43ad9c280ec4297b4cb98b7c2e96cd/scipy-1.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a7ebda398f86e56178c2fa94cad15bf457a218a54a35c2a7b4490b9f9cb2676c", size = 37790844, upload-time = "2024-01-20T21:12:12.826Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7f/504b7b3834d8c9229831c6c58a44943e29a34004eeb34c7ff150add4e001/scipy-1.12.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:95e5c750d55cf518c398a8240571b0e0782c2d5a703250872f36eaf737751338", size = 38026369, upload-time = "2024-01-20T21:12:19.69Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/31/91a2a3c5eb85d2bfa86d7c98f2df5d77dcdefb3d80ca9f9037ad04393acf/scipy-1.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:e646d8571804a304e1da01040d21577685ce8e2db08ac58e543eaca063453e1c", size = 45816713, upload-time = "2024-01-20T21:12:26.619Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "80.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/d2/ec1acaaff45caed5c2dedb33b67055ba9d4e96b091094df90762e60135fe/setuptools-80.8.0.tar.gz", hash = "sha256:49f7af965996f26d43c8ae34539c8d99c5042fbff34302ea151eaa9c207cd257", size = 1319720, upload-time = "2025-05-20T14:02:53.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/29/93c53c098d301132196c3238c312825324740851d77a8500a2462c0fd888/setuptools-80.8.0-py3-none-any.whl", hash = "sha256:95a60484590d24103af13b686121328cc2736bee85de8936383111e421b9edc0", size = 1201470, upload-time = "2025-05-20T14:02:51.348Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
+name = "shortuuid"
+version = "1.0.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/e2/bcf761f3bff95856203f9559baf3741c416071dd200c0fc19fad7f078f86/shortuuid-1.0.13.tar.gz", hash = "sha256:3bb9cf07f606260584b1df46399c0b87dd84773e7b25912b7e391e30797c5e72", size = 9662, upload-time = "2024-03-11T20:11:06.879Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/44/21d6bf170bf40b41396480d8d49ad640bca3f2b02139cd52aa1e272830a5/shortuuid-1.0.13-py3-none-any.whl", hash = "sha256:a482a497300b49b4953e15108a7913244e1bb0d41f9d332f5e9925dba33a3c5a", size = 10529, upload-time = "2024-03-11T20:11:04.807Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "smart-open"
+version = "7.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/be/a66598b305763861a9ab15ff0f2fbc44e47b1ce7a776797337a4eef37c66/smart_open-7.5.1.tar.gz", hash = "sha256:3f08e16827c4733699e6b2cc40328a3568f900cb12ad9a3ad233ba6c872d9fe7", size = 54034, upload-time = "2026-02-23T11:01:28.979Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/ea/dcdecd68acebb49d3fd560473a43499b1635076f7f1ae8641c060fe7ce74/smart_open-7.5.1-py3-none-any.whl", hash = "sha256:3e07cbbd9c8a908bcb8e25d48becf1a5cbb4886fa975e9f34c672ed171df2318", size = 64108, upload-time = "2026-02-23T11:01:27.429Z" },
 ]
 
 [[package]]
@@ -1781,12 +2171,156 @@ wheels = [
 ]
 
 [[package]]
+name = "snowballstemmer"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/a7/9810d872919697c9d01295633f5d574fb416d47e535f258272ca1f01f447/snowballstemmer-3.0.1.tar.gz", hash = "sha256:6d5eeeec8e9f84d4d56b847692bacf79bc2c8e90c7f80ca4444ff8b6f2e52895", size = 105575, upload-time = "2025-05-09T16:34:51.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/78/3565d011c61f5a43488987ee32b6f3f656e7f107ac2782dd57bdd7d91d9a/snowballstemmer-3.0.1-py3-none-any.whl", hash = "sha256:6cd7b3897da8d6c9ffb968a6781fa6532dce9c3618a4b127d920dab764a19064", size = 103274, upload-time = "2025-05-09T16:34:50.371Z" },
+]
+
+[[package]]
+name = "sparse-dot-topn"
+version = "1.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "psutil" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/08/4100f54cd89779064cf943540cd96fcfb31ea0b0cf4f1133d3e44b692c35/sparse-dot-topn-1.1.5.tar.gz", hash = "sha256:4cc100e1d26b5a675faf89267ea4629cbedebb70edef6154b374ffaf93f3f040", size = 45430, upload-time = "2024-10-18T16:31:01.015Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/ff/c50653a3226599de2691eb29b8908c51d0d83159e001f38e8c84c4ea57a6/sparse_dot_topn-1.1.5-cp312-abi3-macosx_12_0_arm64.whl", hash = "sha256:a6cf5b0c47af4a909839dec20f2b51eebb95a2d01c0a41a480fcc9b2b8ea0b3c", size = 443383, upload-time = "2024-10-18T16:30:41.78Z" },
+    { url = "https://files.pythonhosted.org/packages/24/05/90fcab6ef509f600e5f548f39753e713b631f6d2add040d09a4282a9367d/sparse_dot_topn-1.1.5-cp312-abi3-macosx_12_0_x86_64.whl", hash = "sha256:f7db995582f07b5c9061c519027abbdc6984370bb6925b423a71f719d3553f0e", size = 506390, upload-time = "2024-10-18T16:30:43.78Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/8f/724a144122fcd7276068e389ad900f7c9138d00df5686957bed3ff790dd3/sparse_dot_topn-1.1.5-cp312-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b5d57ed9948363be47dafe6925ed70254597671cbeb08d43e443a0f444b03601", size = 264887, upload-time = "2024-10-18T16:30:45.06Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/36/f5574123f89488022e91662775268bbd8691ef3beb66f5ad7e9ce525055b/sparse_dot_topn-1.1.5-cp312-abi3-win_amd64.whl", hash = "sha256:1c08ab8c2c5c834118a2be1274ab116d4f3470d14665e8771e98e89478d8fadb", size = 420350, upload-time = "2024-10-18T16:30:46.228Z" },
+]
+
+[[package]]
+name = "sphinx"
+version = "8.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils" },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals-py" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/ad/4360e50ed56cb483667b8e6dadf2d3fda62359593faabbe749a27c4eaca6/sphinx-8.2.3.tar.gz", hash = "sha256:398ad29dee7f63a75888314e9424d40f52ce5a6a87ae88e7071e80af296ec348", size = 8321876, upload-time = "2025-03-02T22:31:59.658Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/53/136e9eca6e0b9dc0e1962e2c908fbea2e5ac000c2a2fbd9a35797958c48b/sphinx-8.2.3-py3-none-any.whl", hash = "sha256:4405915165f13521d875a8c29c8970800a0141c14cc5416a38feca4ea5d9b9c3", size = 3589741, upload-time = "2025-03-02T22:31:56.836Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-applehelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/6e/b837e84a1a704953c62ef8776d45c3e8d759876b4a84fe14eba2859106fe/sphinxcontrib_applehelp-2.0.0.tar.gz", hash = "sha256:2f29ef331735ce958efa4734873f084941970894c6090408b079c61b2e1c06d1", size = 20053, upload-time = "2024-07-29T01:09:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/85/9ebeae2f76e9e77b952f4b274c27238156eae7979c5421fba91a28f4970d/sphinxcontrib_applehelp-2.0.0-py3-none-any.whl", hash = "sha256:4cd3f0ec4ac5dd9c17ec65e9ab272c9b867ea77425228e68ecf08d6b28ddbdb5", size = 119300, upload-time = "2024-07-29T01:08:58.99Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-devhelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/d2/5beee64d3e4e747f316bae86b55943f51e82bb86ecd325883ef65741e7da/sphinxcontrib_devhelp-2.0.0.tar.gz", hash = "sha256:411f5d96d445d1d73bb5d52133377b4248ec79db5c793ce7dbe59e074b4dd1ad", size = 12967, upload-time = "2024-07-29T01:09:23.417Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl", hash = "sha256:aefb8b83854e4b0998877524d1029fd3e6879210422ee3780459e28a1f03a8a2", size = 82530, upload-time = "2024-07-29T01:09:21.945Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-htmlhelp"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/93/983afd9aa001e5201eab16b5a444ed5b9b0a7a010541e0ddfbbfd0b2470c/sphinxcontrib_htmlhelp-2.1.0.tar.gz", hash = "sha256:c9e2916ace8aad64cc13a0d233ee22317f2b9025b9cf3295249fa985cc7082e9", size = 22617, upload-time = "2024-07-29T01:09:37.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/7b/18a8c0bcec9182c05a0b3ec2a776bba4ead82750a55ff798e8d406dae604/sphinxcontrib_htmlhelp-2.1.0-py3-none-any.whl", hash = "sha256:166759820b47002d22914d64a075ce08f4c46818e17cfc9470a9786b759b19f8", size = 98705, upload-time = "2024-07-29T01:09:36.407Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-jsmath"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/e8/9ed3830aeed71f17c026a07a5097edcf44b692850ef215b161b8ad875729/sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8", size = 5787, upload-time = "2019-01-21T16:10:16.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl", hash = "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178", size = 5071, upload-time = "2019-01-21T16:10:14.333Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-qthelp"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/bc/9104308fc285eb3e0b31b67688235db556cd5b0ef31d96f30e45f2e51cae/sphinxcontrib_qthelp-2.0.0.tar.gz", hash = "sha256:4fe7d0ac8fc171045be623aba3e2a8f613f8682731f9153bb2e40ece16b9bbab", size = 17165, upload-time = "2024-07-29T01:09:56.435Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/83/859ecdd180cacc13b1f7e857abf8582a64552ea7a061057a6c716e790fce/sphinxcontrib_qthelp-2.0.0-py3-none-any.whl", hash = "sha256:b18a828cdba941ccd6ee8445dbe72ffa3ef8cbe7505d8cd1fa0d42d3f2d5f3eb", size = 88743, upload-time = "2024-07-29T01:09:54.885Z" },
+]
+
+[[package]]
+name = "sphinxcontrib-serializinghtml"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/44/6716b257b0aa6bfd51a1b31665d1c205fb12cb5ad56de752dfa15657de2f/sphinxcontrib_serializinghtml-2.0.0.tar.gz", hash = "sha256:e9d912827f872c029017a53f0ef2180b327c3f7fd23c87229f7a8e8b70031d4d", size = 16080, upload-time = "2024-07-29T01:10:09.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/a7/d2782e4e3f77c8450f727ba74a8f12756d5ba823d81b941f1b04da9d033a/sphinxcontrib_serializinghtml-2.0.0-py3-none-any.whl", hash = "sha256:6e2cb0eef194e10c27ec0023bfeb25badbbb5868244cf5bc5bdc04e4464bf331", size = 92072, upload-time = "2024-07-29T01:10:08.203Z" },
+]
+
+[[package]]
 name = "tenacity"
 version = "9.1.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "text2term"
+version = "4.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argparse" },
+    { name = "bioregistry" },
+    { name = "gensim" },
+    { name = "myst-parser" },
+    { name = "nltk" },
+    { name = "numpy" },
+    { name = "owlready2" },
+    { name = "pandas" },
+    { name = "rapidfuzz" },
+    { name = "requests" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "setuptools" },
+    { name = "shortuuid" },
+    { name = "sparse-dot-topn" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/1b/2ab151a2d1414015905c27be49f3c95156e0f052a1cd5a3e3b2cfe3a3ca0/text2term-4.5.0.tar.gz", hash = "sha256:23c9a75f671599a643a029824d1d20db06b0dfc171132bb113fb11a32a494319", size = 44456, upload-time = "2025-05-31T23:16:37.956Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/01/e8e2fcb4c7798fe8e4129ed7eb3eab8cedd23a68b829dd4d0e30d5e1f020/text2term-4.5.0-py3-none-any.whl", hash = "sha256:f6d8478598a0b9c4cf8e8f655dfbc9fb97ac541cffa61ac47739ce8e3d289fb5", size = 38240, upload-time = "2025-05-31T23:16:36.195Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
 ]
 
 [[package]]
@@ -1970,6 +2504,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tzdata"
+version = "2025.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
+]
+
+[[package]]
 name = "urllib3"
 version = "2.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1990,6 +2533,70 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a7/ca/f23dcb02e161a9bba141b1c08aa50e8da6ea25e6d780528f1d385a3efe25/virtualenv-20.29.1.tar.gz", hash = "sha256:b8b8970138d32fb606192cb97f6cd4bb644fa486be9308fb9b63f81091b5dc35", size = 7658028, upload-time = "2025-01-17T17:32:23.085Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/89/9b/599bcfc7064fbe5740919e78c5df18e5dceb0887e676256a1061bb5ae232/virtualenv-20.29.1-py3-none-any.whl", hash = "sha256:4e4cb403c0b0da39e13b46b1b2476e505cb0046b25f242bee80f62bf990b2779", size = 4282379, upload-time = "2025-01-17T17:32:19.864Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/64/925f213fdcbb9baeb1530449ac71a4d57fc361c053d06bf78d0c5c7cd80c/wrapt-2.1.2.tar.gz", hash = "sha256:3996a67eecc2c68fd47b4e3c564405a5777367adfd9b8abb58387b63ee83b21e", size = 81678, upload-time = "2026-03-06T02:53:25.134Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/b6/1db817582c49c7fcbb7df6809d0f515af29d7c2fbf57eb44c36e98fb1492/wrapt-2.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ff2aad9c4cda28a8f0653fc2d487596458c2a3f475e56ba02909e950a9efa6a9", size = 61255, upload-time = "2026-03-06T02:52:45.663Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/16/9b02a6b99c09227c93cd4b73acc3678114154ec38da53043c0ddc1fba0dc/wrapt-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6433ea84e1cfacf32021d2a4ee909554ade7fd392caa6f7c13f1f4bf7b8e8748", size = 61848, upload-time = "2026-03-06T02:53:48.728Z" },
+    { url = "https://files.pythonhosted.org/packages/af/aa/ead46a88f9ec3a432a4832dfedb84092fc35af2d0ba40cd04aea3889f247/wrapt-2.1.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c20b757c268d30d6215916a5fa8461048d023865d888e437fab451139cad6c8e", size = 121433, upload-time = "2026-03-06T02:54:40.328Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/9f/742c7c7cdf58b59085a1ee4b6c37b013f66ac33673a7ef4aaed5e992bc33/wrapt-2.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:79847b83eb38e70d93dc392c7c5b587efe65b3e7afcc167aa8abd5d60e8761c8", size = 123013, upload-time = "2026-03-06T02:53:26.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/44/2c3dd45d53236b7ed7c646fcf212251dc19e48e599debd3926b52310fafb/wrapt-2.1.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f8fba1bae256186a83d1875b2b1f4e2d1242e8fac0f58ec0d7e41b26967b965c", size = 117326, upload-time = "2026-03-06T02:53:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/74/e2/b17d66abc26bd96f89dec0ecd0ef03da4a1286e6ff793839ec431b9fae57/wrapt-2.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e3d3b35eedcf5f7d022291ecd7533321c4775f7b9cd0050a31a68499ba45757c", size = 121444, upload-time = "2026-03-06T02:54:09.5Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/62/e2977843fdf9f03daf1586a0ff49060b1b2fc7ff85a7ea82b6217c1ae36e/wrapt-2.1.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6f2c5390460de57fa9582bc8a1b7a6c86e1a41dfad74c5225fc07044c15cc8d1", size = 116237, upload-time = "2026-03-06T02:54:03.884Z" },
+    { url = "https://files.pythonhosted.org/packages/88/dd/27fc67914e68d740bce512f11734aec08696e6b17641fef8867c00c949fc/wrapt-2.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7dfa9f2cf65d027b951d05c662cc99ee3bd01f6e4691ed39848a7a5fffc902b2", size = 120563, upload-time = "2026-03-06T02:53:20.412Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9f/b750b3692ed2ef4705cb305bd68858e73010492b80e43d2a4faa5573cbe7/wrapt-2.1.2-cp312-cp312-win32.whl", hash = "sha256:eba8155747eb2cae4a0b913d9ebd12a1db4d860fc4c829d7578c7b989bd3f2f0", size = 58198, upload-time = "2026-03-06T02:53:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/b2/feecfe29f28483d888d76a48f03c4c4d8afea944dbee2b0cd3380f9df032/wrapt-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1c51c738d7d9faa0b3601708e7e2eda9bf779e1b601dce6c77411f2a1b324a63", size = 60441, upload-time = "2026-03-06T02:52:47.138Z" },
+    { url = "https://files.pythonhosted.org/packages/44/e1/e328f605d6e208547ea9fd120804fcdec68536ac748987a68c47c606eea8/wrapt-2.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:c8e46ae8e4032792eb2f677dbd0d557170a8e5524d22acc55199f43efedd39bf", size = 58836, upload-time = "2026-03-06T02:53:22.053Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/7a/d936840735c828b38d26a854e85d5338894cda544cb7a85a9d5b8b9c4df7/wrapt-2.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:787fd6f4d67befa6fe2abdffcbd3de2d82dfc6fb8a6d850407c53332709d030b", size = 61259, upload-time = "2026-03-06T02:53:41.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/88/9a9b9a90ac8ca11c2fdb6a286cb3a1fc7dd774c00ed70929a6434f6bc634/wrapt-2.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4bdf26e03e6d0da3f0e9422fd36bcebf7bc0eeb55fdf9c727a09abc6b9fe472e", size = 61851, upload-time = "2026-03-06T02:52:48.672Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a9/5b7d6a16fd6533fed2756900fc8fc923f678179aea62ada6d65c92718c00/wrapt-2.1.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bbac24d879aa22998e87f6b3f481a5216311e7d53c7db87f189a7a0266dafffb", size = 121446, upload-time = "2026-03-06T02:54:14.013Z" },
+    { url = "https://files.pythonhosted.org/packages/45/bb/34c443690c847835cfe9f892be78c533d4f32366ad2888972c094a897e39/wrapt-2.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16997dfb9d67addc2e3f41b62a104341e80cac52f91110dece393923c0ebd5ca", size = 123056, upload-time = "2026-03-06T02:54:10.829Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b9/ff205f391cb708f67f41ea148545f2b53ff543a7ac293b30d178af4d2271/wrapt-2.1.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:162e4e2ba7542da9027821cb6e7c5e068d64f9a10b5f15512ea28e954893a267", size = 117359, upload-time = "2026-03-06T02:53:03.623Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3d/1ea04d7747825119c3c9a5e0874a40b33594ada92e5649347c457d982805/wrapt-2.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f29c827a8d9936ac320746747a016c4bc66ef639f5cd0d32df24f5eacbf9c69f", size = 121479, upload-time = "2026-03-06T02:53:45.844Z" },
+    { url = "https://files.pythonhosted.org/packages/78/cc/ee3a011920c7a023b25e8df26f306b2484a531ab84ca5c96260a73de76c0/wrapt-2.1.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:a9dd9813825f7ecb018c17fd147a01845eb330254dff86d3b5816f20f4d6aaf8", size = 116271, upload-time = "2026-03-06T02:54:46.356Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fd/e5ff7ded41b76d802cf1191288473e850d24ba2e39a6ec540f21ae3b57cb/wrapt-2.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f8dbdd3719e534860d6a78526aafc220e0241f981367018c2875178cf83a413", size = 120573, upload-time = "2026-03-06T02:52:50.163Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c5/242cae3b5b080cd09bacef0591691ba1879739050cc7c801ff35c8886b66/wrapt-2.1.2-cp313-cp313-win32.whl", hash = "sha256:5c35b5d82b16a3bc6e0a04349b606a0582bc29f573786aebe98e0c159bc48db6", size = 58205, upload-time = "2026-03-06T02:53:47.494Z" },
+    { url = "https://files.pythonhosted.org/packages/12/69/c358c61e7a50f290958809b3c61ebe8b3838ea3e070d7aac9814f95a0528/wrapt-2.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:f8bc1c264d8d1cf5b3560a87bbdd31131573eb25f9f9447bb6252b8d4c44a3a1", size = 60452, upload-time = "2026-03-06T02:53:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/66/c8a6fcfe321295fd8c0ab1bd685b5a01462a9b3aa2f597254462fc2bc975/wrapt-2.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:3beb22f674550d5634642c645aba4c72a2c66fb185ae1aebe1e955fae5a13baf", size = 58842, upload-time = "2026-03-06T02:52:52.114Z" },
+    { url = "https://files.pythonhosted.org/packages/da/55/9c7052c349106e0b3f17ae8db4b23a691a963c334de7f9dbd60f8f74a831/wrapt-2.1.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0fc04bc8664a8bc4c8e00b37b5355cffca2535209fba1abb09ae2b7c76ddf82b", size = 63075, upload-time = "2026-03-06T02:53:19.108Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a8/ce7b4006f7218248dd71b7b2b732d0710845a0e49213b18faef64811ffef/wrapt-2.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a9b9d50c9af998875a1482a038eb05755dfd6fe303a313f6a940bb53a83c3f18", size = 63719, upload-time = "2026-03-06T02:54:33.452Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e5/2ca472e80b9e2b7a17f106bb8f9df1db11e62101652ce210f66935c6af67/wrapt-2.1.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2d3ff4f0024dd224290c0eabf0240f1bfc1f26363431505fb1b0283d3b08f11d", size = 152643, upload-time = "2026-03-06T02:52:42.721Z" },
+    { url = "https://files.pythonhosted.org/packages/36/42/30f0f2cefca9d9cbf6835f544d825064570203c3e70aa873d8ae12e23791/wrapt-2.1.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3278c471f4468ad544a691b31bb856374fbdefb7fee1a152153e64019379f015", size = 158805, upload-time = "2026-03-06T02:54:25.441Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/67/d08672f801f604889dcf58f1a0b424fe3808860ede9e03affc1876b295af/wrapt-2.1.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a8914c754d3134a3032601c6984db1c576e6abaf3fc68094bb8ab1379d75ff92", size = 145990, upload-time = "2026-03-06T02:53:57.456Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a7/fd371b02e73babec1de6ade596e8cd9691051058cfdadbfd62a5898f3295/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ff95d4264e55839be37bafe1536db2ab2de19da6b65f9244f01f332b5286cfbf", size = 155670, upload-time = "2026-03-06T02:54:55.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2d/9fe0095dfdb621009f40117dcebf41d7396c2c22dca6eac779f4c007b86c/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:76405518ca4e1b76fbb1b9f686cff93aebae03920cc55ceeec48ff9f719c5f67", size = 144357, upload-time = "2026-03-06T02:54:24.092Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b6/ec7b4a254abbe4cde9fa15c5d2cca4518f6b07d0f1b77d4ee9655e30280e/wrapt-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c0be8b5a74c5824e9359b53e7e58bef71a729bacc82e16587db1c4ebc91f7c5a", size = 150269, upload-time = "2026-03-06T02:53:31.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6b/2fabe8ebf148f4ee3c782aae86a795cc68ffe7d432ef550f234025ce0cfa/wrapt-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:f01277d9a5fc1862f26f7626da9cf443bebc0abd2f303f41c5e995b15887dabd", size = 59894, upload-time = "2026-03-06T02:54:15.391Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/fb/9ba66fc2dedc936de5f8073c0217b5d4484e966d87723415cc8262c5d9c2/wrapt-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:84ce8f1c2104d2f6daa912b1b5b039f331febfeee74f8042ad4e04992bd95c8f", size = 63197, upload-time = "2026-03-06T02:54:41.943Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1c/012d7423c95d0e337117723eb8ecf73c622ce15a97847e84cf3f8f26cd7e/wrapt-2.1.2-cp313-cp313t-win_arm64.whl", hash = "sha256:a93cd767e37faeddbe07d8fc4212d5cba660af59bdb0f6372c93faaa13e6e679", size = 60363, upload-time = "2026-03-06T02:54:48.093Z" },
+    { url = "https://files.pythonhosted.org/packages/39/25/e7ea0b417db02bb796182a5316398a75792cd9a22528783d868755e1f669/wrapt-2.1.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1370e516598854e5b4366e09ce81e08bfe94d42b0fd569b88ec46cc56d9164a9", size = 61418, upload-time = "2026-03-06T02:53:55.706Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0f/fa539e2f6a770249907757eaeb9a5ff4deb41c026f8466c1c6d799088a9b/wrapt-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6de1a3851c27e0bd6a04ca993ea6f80fc53e6c742ee1601f486c08e9f9b900a9", size = 61914, upload-time = "2026-03-06T02:52:53.37Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/02af1867f5b1441aaeda9c82deed061b7cd1372572ddcd717f6df90b5e93/wrapt-2.1.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:de9f1a2bbc5ac7f6012ec24525bdd444765a2ff64b5985ac6e0692144838542e", size = 120417, upload-time = "2026-03-06T02:54:30.74Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b7/0138a6238c8ba7476c77cf786a807f871672b37f37a422970342308276e7/wrapt-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:970d57ed83fa040d8b20c52fe74a6ae7e3775ae8cff5efd6a81e06b19078484c", size = 122797, upload-time = "2026-03-06T02:54:51.539Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/ad/819ae558036d6a15b7ed290d5b14e209ca795dd4da9c58e50c067d5927b0/wrapt-2.1.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3969c56e4563c375861c8df14fa55146e81ac11c8db49ea6fb7f2ba58bc1ff9a", size = 117350, upload-time = "2026-03-06T02:54:37.651Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/2d/afc18dc57a4600a6e594f77a9ae09db54f55ba455440a54886694a84c71b/wrapt-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:57d7c0c980abdc5f1d98b11a2aa3bb159790add80258c717fa49a99921456d90", size = 121223, upload-time = "2026-03-06T02:54:35.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/5b/5ec189b22205697bc56eb3b62aed87a1e0423e9c8285d0781c7a83170d15/wrapt-2.1.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:776867878e83130c7a04237010463372e877c1c994d449ca6aaafeab6aab2586", size = 116287, upload-time = "2026-03-06T02:54:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/2d/f84939a7c9b5e6cdd8a8d0f6a26cabf36a0f7e468b967720e8b0cd2bdf69/wrapt-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:fab036efe5464ec3291411fabb80a7a39e2dd80bae9bcbeeca5087fdfa891e19", size = 119593, upload-time = "2026-03-06T02:54:16.697Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/fe/ccd22a1263159c4ac811ab9374c061bcb4a702773f6e06e38de5f81a1bdc/wrapt-2.1.2-cp314-cp314-win32.whl", hash = "sha256:e6ed62c82ddf58d001096ae84ce7f833db97ae2263bff31c9b336ba8cfe3f508", size = 58631, upload-time = "2026-03-06T02:53:06.498Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0a/6bd83be7bff2e7efaac7b4ac9748da9d75a34634bbbbc8ad077d527146df/wrapt-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:467e7c76315390331c67073073d00662015bb730c566820c9ca9b54e4d67fd04", size = 60875, upload-time = "2026-03-06T02:53:50.252Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c0/0b3056397fe02ff80e5a5d72d627c11eb885d1ca78e71b1a5c1e8c7d45de/wrapt-2.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:da1f00a557c66225d53b095a97eace0fc5349e3bfda28fa34ffae238978ee575", size = 59164, upload-time = "2026-03-06T02:53:59.128Z" },
+    { url = "https://files.pythonhosted.org/packages/71/ed/5d89c798741993b2371396eb9d4634f009ff1ad8a6c78d366fe2883ea7a6/wrapt-2.1.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:62503ffbc2d3a69891cf29beeaccdb4d5e0a126e2b6a851688d4777e01428dbb", size = 63163, upload-time = "2026-03-06T02:52:54.873Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8c/05d277d182bf36b0a13d6bd393ed1dec3468a25b59d01fba2dd70fe4d6ae/wrapt-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c7e6cd120ef837d5b6f860a6ea3745f8763805c418bb2f12eeb1fa6e25f22d22", size = 63723, upload-time = "2026-03-06T02:52:56.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/27/6c51ec1eff4413c57e72d6106bb8dec6f0c7cdba6503d78f0fa98767bcc9/wrapt-2.1.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3769a77df8e756d65fbc050333f423c01ae012b4f6731aaf70cf2bef61b34596", size = 152652, upload-time = "2026-03-06T02:53:23.79Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4c/d7dd662d6963fc7335bfe29d512b02b71cdfa23eeca7ab3ac74a67505deb/wrapt-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a76d61a2e851996150ba0f80582dd92a870643fa481f3b3846f229de88caf044", size = 158807, upload-time = "2026-03-06T02:53:35.742Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/4d/1e5eea1a78d539d346765727422976676615814029522c76b87a95f6bcdd/wrapt-2.1.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6f97edc9842cf215312b75fe737ee7c8adda75a89979f8e11558dfff6343cc4b", size = 146061, upload-time = "2026-03-06T02:52:57.574Z" },
+    { url = "https://files.pythonhosted.org/packages/89/bc/62cabea7695cd12a288023251eeefdcb8465056ddaab6227cb78a2de005b/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4006c351de6d5007aa33a551f600404ba44228a89e833d2fadc5caa5de8edfbf", size = 155667, upload-time = "2026-03-06T02:53:39.422Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/99/6f2888cd68588f24df3a76572c69c2de28287acb9e1972bf0c83ce97dbc1/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a9372fc3639a878c8e7d87e1556fa209091b0a66e912c611e3f833e2c4202be2", size = 144392, upload-time = "2026-03-06T02:54:22.41Z" },
+    { url = "https://files.pythonhosted.org/packages/40/51/1dfc783a6c57971614c48e361a82ca3b6da9055879952587bc99fe1a7171/wrapt-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3144b027ff30cbd2fca07c0a87e67011adb717eb5f5bd8496325c17e454257a3", size = 150296, upload-time = "2026-03-06T02:54:07.848Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/38/cbb8b933a0201076c1f64fc42883b0023002bdc14a4964219154e6ff3350/wrapt-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:3b8d15e52e195813efe5db8cec156eebe339aaf84222f4f4f051a6c01f237ed7", size = 60539, upload-time = "2026-03-06T02:54:00.594Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/e5176e4b241c9f528402cebb238a36785a628179d7d8b71091154b3e4c9e/wrapt-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:08ffa54146a7559f5b8df4b289b46d963a8e74ed16ba3687f99896101a3990c5", size = 63969, upload-time = "2026-03-06T02:54:39Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/99/79f17046cf67e4a95b9987ea129632ba8bcec0bc81f3fb3d19bdb0bd60cd/wrapt-2.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:72aaa9d0d8e4ed0e2e98019cea47a21f823c9dd4b43c7b77bba6679ffcca6a00", size = 60554, upload-time = "2026-03-06T02:53:14.132Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/c7/8528ac2dfa2c1e6708f647df7ae144ead13f0a31146f43c7264b4942bf12/wrapt-2.1.2-py3-none-any.whl", hash = "sha256:b8fd6fa2b2c4e7621808f8c62e8317f4aae56e59721ad933bac5239d913cf0e8", size = 43993, upload-time = "2026-03-06T02:53:12.905Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -302,6 +302,19 @@ wheels = [
 ]
 
 [[package]]
+name = "class-resolver"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", version = "4.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/31/4fc27f245886ee5a545819b96780c1b81e87a4c7f82e2236c1e183ec33dd/class_resolver-0.7.1.tar.gz", hash = "sha256:86f73b8cc5ed9111b7d9c5e331b51856a32f205179c66a56a9c520d0f6e82f66", size = 27045, upload-time = "2025-08-28T12:57:59.81Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/f7/6718949c6689c3fcf934fee08f572e4493d4d3e85a95fe76a80e74b0c4e3/class_resolver-0.7.1-py3-none-any.whl", hash = "sha256:d177909a48fdf6d6a0c297d117742a83ea799e0f601a922aa9ccb23ca1200e00", size = 31995, upload-time = "2025-08-28T12:57:58.401Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
@@ -1198,6 +1211,22 @@ wheels = [
 ]
 
 [[package]]
+name = "ols-client"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "class-resolver" },
+    { name = "click" },
+    { name = "more-click" },
+    { name = "pystow" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/6e/13b086c5712370029f592ddc99110a004697e696be70fbe3899125cba086/ols_client-0.2.1.tar.gz", hash = "sha256:c5078446f025e2fbe24a1a2bbb924d7372216ca05e7ff11dba87aa7721be008a", size = 12563, upload-time = "2025-08-04T09:31:26.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/73/81d0ea2ab7f54e45060f6ea7121300ee0e4d4c78cda6c24bd636677a9a94/ols_client-0.2.1-py3-none-any.whl", hash = "sha256:e6d094b8d49711ed2b173b06bd3fbc62be4c8becd21def3bf4efec59096fcca8", size = 13003, upload-time = "2025-08-04T09:31:25.092Z" },
+]
+
+[[package]]
 name = "openai"
 version = "2.28.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1229,6 +1258,7 @@ dependencies = [
     { name = "jsonschema" },
     { name = "litellm" },
     { name = "ollama" },
+    { name = "ols-client" },
     { name = "polars" },
     { name = "pyarrow" },
     { name = "pydantic", version = "2.10.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
@@ -1240,6 +1270,7 @@ dependencies = [
 
 [package.optional-dependencies]
 text2term = [
+    { name = "bioregistry" },
     { name = "text2term" },
 ]
 
@@ -1253,12 +1284,14 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "bioregistry", marker = "extra == 'text2term'", specifier = ">=0.11.35" },
     { name = "click", specifier = ">=8.1.8,<9" },
     { name = "datamodel-code-generator", specifier = ">=0.55.0" },
     { name = "instructor", specifier = ">=1.14.5" },
     { name = "jsonschema", specifier = ">=4.23.0,<5" },
     { name = "litellm", specifier = ">=1.82.2" },
     { name = "ollama", specifier = ">=0.5.1,<0.6" },
+    { name = "ols-client", specifier = ">=0.2.1" },
     { name = "polars", specifier = ">=1.38.1" },
     { name = "pyarrow", specifier = ">=20.0.0,<21" },
     { name = "pydantic", specifier = ">=2.10.6,<3" },


### PR DESCRIPTION
Closes #16.

Allows a user to enrich an existing machine-readable definition or create a new one with ontology ids out of the box.

This is still experimental. Feedback is welcome!